### PR TITLE
Prefix apt-get commands with travis_retry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ env:
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
- - sudo add-apt-repository -y ppa:hvr/ghc
- - sudo apt-get update
- - sudo apt-get install cabal-install-1.18 ghc-$GHCVER happy
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-1.18 ghc-$GHCVER happy
  - export PATH=/opt/ghc/$GHCVER/bin:$PATH
 
 install:


### PR DESCRIPTION
This is a workaround for network connectivity issues that can cause spurious errors sometimes. See http://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/
