### PR TITLE
Update dependencies to ShellCheck 0.5.x

### DIFF
--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -89,7 +89,7 @@ library
 
   -- ShellCheck. Would need newer transformers for older GHC
   if flag(ShellCheck) && impl(ghc >= 7.10 && <8.3)
-    build-depends: ShellCheck == 0.4.7
+    build-depends: ShellCheck == 0.5.*
 
 executable make-travis-yml
   main-is:             Main.hs


### PR DESCRIPTION
The build and test suite both succeed fine with the new version.