### PR TITLE
Fix #186

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
   # test that source-distributions can be generated
-  - cabal new-sdist all
+  - (cd "." && cabal new-sdist)
   - mv dist-newstyle/sdist/*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;

--- a/fixtures/cabal.project.empty-line.travis.yml
+++ b/fixtures/cabal.project.empty-line.travis.yml
@@ -150,7 +150,10 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
   # test that source-distributions can be generated
-  - cabal new-sdist all
+  - (cd "servant" && cabal new-sdist)
+  - (cd "servant-client" && cabal new-sdist)
+  - (cd "servant-docs" && cabal new-sdist)
+  - (cd "servant-server" && cabal new-sdist)
   - mv dist-newstyle/sdist/*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;

--- a/fixtures/cabal.project.messy.travis.yml
+++ b/fixtures/cabal.project.messy.travis.yml
@@ -148,7 +148,10 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
   # test that source-distributions can be generated
-  - cabal new-sdist all
+  - (cd "servant" && cabal new-sdist)
+  - (cd "servant-client" && cabal new-sdist)
+  - (cd "servant-docs" && cabal new-sdist)
+  - (cd "servant-server" && cabal new-sdist)
   - mv dist-newstyle/sdist/*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -876,6 +876,8 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
 
     foldedTellStrLns FoldSDist "Packaging..." folds $ do
         forM_ pkgs $ \Pkg{pkgDir} -> tellStrLns
+            -- Why not just perform a single `cabal new-sdist all`?
+            -- See haskell/cabal#5586.
             [ sh $ "(cd \"" ++ pkgDir ++ "\" && cabal new-sdist)"
             ]
 

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -875,8 +875,8 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
         ]
 
     foldedTellStrLns FoldSDist "Packaging..." folds $ do
-        tellStrLns
-            [ sh $ "cabal new-sdist all"
+        forM_ pkgs $ \Pkg{pkgDir} -> tellStrLns
+            [ sh $ "(cd \"" ++ pkgDir ++ "\" && cabal new-sdist)"
             ]
 
     let tarFiles = "dist-newstyle" </> "sdist" </> "*.tar.gz"


### PR DESCRIPTION
Avoid `Cabal` bugs haskell/cabal#5586 and haskell/cabal#5612 by explicitly enumerating the packages to `new-sdist`.