### PR TITLE
Remove sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
 language: c
-sudo: false
 
 git:
   submodules: false  # whether to recursively clone submodules

--- a/README.md
+++ b/README.md
@@ -157,9 +157,6 @@ The following `.travis.yml` snippet shows the different `matrix` and
 ```yaml
 language: c
 
-# explicitly request container-based infrastructure
-sudo: false
-
 matrix:
   include:
     - env: CABALVER=1.16 GHCVER=7.6.3

--- a/fixtures/cabal.project.empty-line.travis.yml
+++ b/fixtures/cabal.project.empty-line.travis.yml
@@ -5,7 +5,6 @@
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
 language: c
-sudo: false
 
 git:
   submodules: false  # whether to recursively clone submodules

--- a/fixtures/cabal.project.messy.travis.yml
+++ b/fixtures/cabal.project.messy.travis.yml
@@ -5,7 +5,6 @@
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
 language: c
-sudo: false
 
 git:
   submodules: false  # whether to recursively clone submodules

--- a/make_travis_yml.hs
+++ b/make_travis_yml.hs
@@ -73,7 +73,6 @@ genTravisFromCabalFile fn xpkgs = do
 
     putStrLn "# This file has been generated -- see https://github.com/haskell-CI/haskell-ci"
     putStrLn "language: c"
-    putStrLn "sudo: false"
     putStrLn ""
     putStrLn "cache:"
     putStrLn "  directories:"

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -605,7 +605,6 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
         , "# For more information, see https://github.com/haskell-CI/haskell-ci"
         , "#"
         , "language: c"
-        , "sudo: false"
         , ""
         , "git:"
         , "  submodules: false  # whether to recursively clone submodules"


### PR DESCRIPTION
Container-based Travis envs get phased out soon. See some more details at
https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures
and
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration