### PR TITLE
Remove workaround for haskell/cabal#5516

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,6 @@ install:
   - "sed -i.bak 's/^-- jobs:.*/jobs: 2/' ${HOME}/.cabal/config"
   - "if [ $HCNUMVER -ge 70800 ]; then sed -i.bak 's/-- ghc-options:.*/ghc-options: -j2/' ${HOME}/.cabal/config; fi"
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
-  - (cd /tmp && echo '' | cabal new-repl -w ${HC} --build-dep fail)
   - if [ $HCNUMVER -ge 80000 ]; then cabal new-install -w ${HC} -j2 --symlink-bindir=$HOME/.local/bin doctest --constraint='doctest ==0.16.*'; fi
   - if [ $HCNUMVER -eq 80403 ]; then cabal new-install -w ${HC} -j2 --symlink-bindir=$HOME/.local/bin hlint --constraint='hlint ==2.1.*'; fi
   - "printf 'packages: \".\"\\n' > cabal.project"

--- a/src/MakeTravisYml.hs
+++ b/src/MakeTravisYml.hs
@@ -808,12 +808,6 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
         [ sh "grep -Ev -- '^\\s*--' ${HOME}/.cabal/config | grep -Ev '^\\s*$'"
         ]
 
-    -- Initialise store
-    -- https://github.com/haskell/cabal/issues/5516
-    when (cfgDoctest config || cfgHLint config) $ tellStrLns
-        [ sh "(cd /tmp && echo '' | cabal new-repl -w ${HC} --build-dep fail)"
-        ]
-
     -- Install doctest
     let doctestVersionConstraint
             | isAnyVersion (cfgDoctestVersion config) = ""


### PR DESCRIPTION
Now that haskell/cabal#5516 has been fixed (and was shipped with `cabal-install-2.4.1.0`, see https://github.com/haskell/cabal/issues/5516#issuecomment-446040712), we can remove a hack that was put in place in `haskell-ci` to work around it.