### PR TITLE
Refactor 2019-02-10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
   - "if [ $HCNUMVER -ge 70800 ]; then sed -i.bak 's/-- ghc-options:.*/ghc-options: -j2/' ${HOME}/.cabal/config; fi"
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
   - if [ $HCNUMVER -ge 80000 ]; then cabal new-install -w ${HC} -j2 --symlink-bindir=$HOME/.local/bin doctest --constraint='doctest ==0.16.*'; fi
-  - if [ $HCNUMVER -eq 80403 ]; then cabal new-install -w ${HC} -j2 --symlink-bindir=$HOME/.local/bin hlint --constraint='hlint ==2.1.*'; fi
+  - if [ $HCNUMVER -eq 80603 ]; then cabal new-install -w ${HC} -j2 --symlink-bindir=$HOME/.local/bin hlint --constraint='hlint ==2.1.*'; fi
   - "printf 'packages: \".\"\\n' > cabal.project"
   - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - echo 'package haskell-ci' >> cabal.project

--- a/Main.hs
+++ b/Main.hs
@@ -1,2 +1,0 @@
-module Main (main) where
-import MakeTravisYml (main)

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -1,0 +1,2 @@
+module Main (main) where
+import HaskellCI (main)

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,8 +1,7 @@
-cabal-version:       2.2
-name:                haskell-ci
-version:             0.1.0.0
-
-synopsis:            Cabal package script generator for Travis-CI
+cabal-version:      2.2
+name:               haskell-ci
+version:            0.1.0.0
+synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@make-travis-yml@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.
   .
@@ -22,20 +21,15 @@ description:
   .
   See @make-travis-yml --help@ for more information.
 
-  
-homepage:            http://haskell-ci.rtfd.org/
-bug-reports:         https://github.com/haskell-CI/haskell-ci/issues
-license:             BSD-3-Clause
-license-file:        LICENSE
-author:              Herbert Valerio Riedel, Oleg Grenrus
-maintainer:          hvr@gnu.org
-category:            Development
-build-type:          Simple
-tested-with:
-  GHC == 8.0.2,
-  GHC == 8.2.2,
-  GHC == 8.4.4,
-  GHC == 8.6.3
+homepage:           http://haskell-ci.rtfd.org/
+bug-reports:        https://github.com/haskell-CI/haskell-ci/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Herbert Valerio Riedel, Oleg Grenrus
+maintainer:         hvr@gnu.org
+category:           Development
+build-type:         Simple
+tested-with:        GHC ==8.6.3 || ==8.4.4 || ==8.2.2 || ==8.0.2
 extra-source-files:
   fixtures/cabal.haskell-ci
   fixtures/haskell-ci.cabal
@@ -58,65 +52,76 @@ extra-source-files:
   fixtures/servant/*.cabal
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/haskell-CI/haskell-ci.git
 
 flag ShellCheck
   default: True
-  manual: True
+  manual:  True
 
 library
   exposed-modules:
-    MakeTravisYml
-    Config
-    Glob
+    HaskellCI
+    HaskellCI.Config
+    HaskellCI.Glob
+
   ghc-options:
-    -Wall
-    -Wcompat
-    -Wnoncanonical-monad-instances
+    -Wall -Wcompat -Wnoncanonical-monad-instances
     -Wnoncanonical-monadfail-instances
-  hs-source-dirs:      src
-  other-extensions:    CPP, ViewPatterns, NamedFieldPuns, OverloadedLabels
+
+  hs-source-dirs:   src
+  other-extensions:
+    CPP
+    NamedFieldPuns
+    OverloadedLabels
+    ViewPatterns
+
   build-depends:
-    , base         >= 4.7  && < 4.13
-    , Cabal        ^>= 2.4
-    , containers   >= 0.4  && < 0.7
-    , directory    >= 1.1  && < 1.4
-    , filepath     >= 1.2  && < 1.5
-    , transformers >= 0.3  && < 0.6
-    , deepseq      >= 1.3  && < 1.5
+    , base          >=4.7 && <4.13
+    , Cabal         ^>=2.4
+    , containers    >=0.4 && <0.7
+    , deepseq       >=1.3 && <1.5
+    , directory     >=1.1 && <1.4
+    , filepath      >=1.2 && <1.5
+    , transformers  >=0.3 && <0.6
 
   -- other dependencies
   build-depends:
-    , generic-lens ^>=1.1.0.0
-    , microlens    ^>=0.4.10
-  default-language:    Haskell2010
+    , generic-lens  ^>=1.1.0.0
+    , microlens     ^>=0.4.10
+
+  default-language: Haskell2010
 
   -- ShellCheck. Would need newer transformers for older GHC
-  if flag(ShellCheck) && impl(ghc >= 7.10 && <8.7)
-    build-depends: ShellCheck == 0.6.0
+  if (flag(shellcheck) && impl(ghc >=7.10 && <8.7))
+    build-depends: ShellCheck ==0.6.0
 
 executable haskell-ci
-  main-is:             Main.hs
-  ghc-options:         -Wall
-  build-depends:       base, haskell-ci
-  default-language:    Haskell2010
+  main-is:          Main.hs
+  ghc-options:      -Wall
+  hs-source-dirs:   cli
+  build-depends:
+    , base
+    , haskell-ci
+
+  default-language: Haskell2010
 
 test-suite golden
-  type:                exitcode-stdio-1.0
-  main-is:             Tests.hs
-  hs-source-dirs:      test
-  build-depends:       haskell-ci
-                       -- inherited constraints via lib:haskell-ci
-                     , base
-                     , bytestring
-                     , directory
-                     , filepath
-                     , transformers
-                       -- dependencies needing explicit constraints
-                     , tasty         >= 1.0      && < 1.2
-                     , tasty-golden  >= 2.3.1.1  && < 2.4
-                     , ansi-terminal >= 0.8.0.2  && <0.9
-                     , Diff          >= 0.3.4    && < 0.4
+  type:             exitcode-stdio-1.0
+  main-is:          Tests.hs
+  hs-source-dirs:   test
+  build-depends:
+    , ansi-terminal  ^>=0.8.0.2
+    , base
+    , bytestring
+    , Diff           ^>=0.3.4
+    , directory
+    , filepath
+    , haskell-ci
+    , tasty          >=1.0     && <1.2
+    , tasty-golden   ^>=2.3.1.1
+    , transformers
 
-  default-language:    Haskell2010
+  -- inherited constraints via lib:haskell-ci
+  -- dependencies needing explicit constraints
+  default-language: Haskell2010

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -63,6 +63,8 @@ library
   exposed-modules:
     HaskellCI
     HaskellCI.Config
+    HaskellCI.Config.Doctest
+    HaskellCI.Config.HLint
     HaskellCI.Glob
 
   ghc-options:

--- a/src/HaskellCI.hs
+++ b/src/HaskellCI.hs
@@ -21,7 +21,7 @@
 --
 -- NB: This code deliberately avoids relying on non-standard packages and
 --     is expected to compile/work with at least GHC 7.0 through GHC 8.0
-module MakeTravisYml (
+module HaskellCI (
     main,
     -- * for tests
     Result (..),
@@ -97,8 +97,8 @@ import Data.Monoid ((<>))
 import Lens.Micro
 import Data.Generics.Labels () -- IsLabel (->) ...
 
-import Config
-import Glob
+import HaskellCI.Config
+import HaskellCI.Glob
 
 #if !(MIN_VERSION_Cabal(2,0,0))
 -- compat helpers for pre-2.0

--- a/src/HaskellCI.hs
+++ b/src/HaskellCI.hs
@@ -98,6 +98,8 @@ import Lens.Micro
 import Data.Generics.Labels () -- IsLabel (->) ...
 
 import HaskellCI.Config
+import HaskellCI.Config.Doctest
+import HaskellCI.Config.HLint
 import HaskellCI.Glob
 
 #if !(MIN_VERSION_Cabal(2,0,0))
@@ -818,7 +820,6 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
         ]
 
     -- Install doctest
-    let doctestConfig = cfgDoctest config
     let doctestVersionConstraint
             | isAnyVersion (cfgDoctestVersion doctestConfig) = ""
             | otherwise = " --constraint='doctest " ++ display (cfgDoctestVersion doctestConfig) ++ "'"
@@ -828,10 +829,10 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
 
     -- Install hlint
     let hlintVersionConstraint
-            | isAnyVersion (cfgHLintVersion config) = ""
-            | otherwise = " --constraint='hlint " ++ display (cfgHLintVersion config) ++ "'"
-    when (cfgHLint config) $ tellStrLns
-        [ sh $ "if [ $HCNUMVER -eq 80403 ]; then cabal new-install -w ${HC} -j2 --symlink-bindir=$HOME/.local/bin hlint" ++ hlintVersionConstraint ++ "; fi"
+            | isAnyVersion (cfgHLintVersion hlintConfig) = ""
+            | otherwise = " --constraint='hlint " ++ display (cfgHLintVersion hlintConfig) ++ "'"
+    when (cfgHLintEnabled hlintConfig) $ tellStrLns
+        [ sh $ "if [ $HCNUMVER -eq " ++ hlintJobVersion versions (cfgHLintJob hlintConfig) ++ " ]; then cabal new-install -w ${HC} -j2 --symlink-bindir=$HOME/.local/bin hlint" ++ hlintVersionConstraint ++ "; fi"
         ]
 
     -- create cabal.project file
@@ -948,7 +949,7 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
                     ]
         tellStrLns [ "" ]
 
-    when (cfgHLint config) $ do
+    when (cfgHLintEnabled hlintConfig) $ do
         let "" <+> ys = ys
             xs <+> "" = xs
             xs <+> ys = xs ++ " " ++ ys
@@ -956,7 +957,7 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
             prependSpace "" = ""
             prependSpace xs = " " ++ xs
 
-        let hlintOptions = prependSpace $ maybe "" ("-h ${ROOTDIR}/" ++) (cfgHLintYaml config) <+> unwords (cfgHLintOptions config)
+        let hlintOptions = prependSpace $ maybe "" ("-h ${ROOTDIR}/" ++) (cfgHLintYaml hlintConfig) <+> unwords (cfgHLintOptions hlintConfig)
 
         tellStrLns [ comment "hlint" ]
         foldedTellStrLns FoldHLint "HLint.." folds $ do
@@ -1040,6 +1041,9 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
 
     return ()
   where
+    doctestConfig = cfgDoctest config
+    hlintConfig   = cfgHLint config
+
     hasTests   = F.any (\Pkg{pkgGpd} -> not . null $ condTestSuites pkgGpd) pkgs
     hasLibrary = F.any (\Pkg{pkgGpd} -> isJust $ condLibrary pkgGpd) pkgs
 
@@ -1171,6 +1175,23 @@ collToGhcVer cid = case simpleParse cid of
     | isPrefixOf [6] v -> mkVersion [7,10,3]
     | isPrefixOf [7] v -> mkVersion [8,0,1]
     | otherwise -> error ("unknown collection " ++ show cid)
+
+-------------------------------------------------------------------------------
+-- HLint
+-------------------------------------------------------------------------------
+
+hlintJobVersion :: Set (Maybe Version) -> HLintJob -> String
+hlintJobVersion vs HLintJobLatest = case S.maxView vs of
+    Just (Just v, _) -> ghcVersionToString v
+    _                -> "80603" -- it really doesn't matter, if there are no jobs
+hlintJobVersion _ (HLintJob v)   = ghcVersionToString v
+
+ghcVersionToString :: Version -> String
+ghcVersionToString v =  case versionNumbers v of
+    []        -> "0"
+    [x]       -> show (x * 10000)
+    [x,y]     -> show (x * 10000 + y * 100)
+    (x:y:z:_) -> show (x * 10000 + y * 100 + z)
 
 -------------------------------------------------------------------------------
 -- Jobs
@@ -1356,16 +1377,16 @@ options =
       (reqArgReadP parse (set $ #cfgDoctest . #cfgDoctestVersion) "VERSION")
       "Doctest version range"
     , Option ['l'] ["hlint"]
-      (NoArg $ successCM $ \cfg -> cfg { cfgHLint = True })
+      (NoArg $ successCM $ set (#cfgHLint . #cfgHLintEnabled) True)
       "Run hlint (only on GHC-8.4.3 target)"
     , Option [] ["hlint-yaml"]
-      (ReqArg (successCM' $ \arg cfg -> cfg { cfgHLintYaml = Just arg }) "HLINT.YAML")
+      (ReqArg (successCM' $ set (#cfgHLint . #cfgHLintYaml) . Just) "HLINT.YAML")
       "Relative path to .hlint.yaml."
     , Option [] ["hlint-options"]
-      (reqArgReadP parseOptsQ (\xs cfg -> cfg { cfgHLintOptions = xs }) "OPTIONS")
+      (reqArgReadP parseOptsQ (set $ #cfgHLint . #cfgHLintOptions) "OPTIONS")
       "Additional hlint options."
     , Option [] ["hlint-version"]
-      (reqArgReadP parse (\arg cfg -> cfg { cfgHLintVersion = arg }) "VERSION")
+      (reqArgReadP parse (set $ #cfgHLint . #cfgHLintVersion) "VERSION")
       "HLint version range"
     , Option [] ["cabal-install-version"]
       (reqArgReadP parse (\arg cfg -> cfg { cfgCabalInstallVersion = Just arg }) "VERSION")
@@ -1478,19 +1499,23 @@ configFieldDescrs =
         cfgJobs
         (\x cfg -> cfg { cfgJobs = x })
     , PU.boolField  "hlint"
-        cfgHLint
-        (\b cfg -> cfg { cfgHLint = b })
+        (view $ #cfgHLint . #cfgHLintEnabled)
+        (set $ #cfgHLint . #cfgHLintEnabled)
     , PU.simpleField "hlint-yaml"
         (error "we don't pretty print")
         (fmap Just PU.parseFilePathQ)
-        cfgHLintYaml
-        (\x cfg -> cfg { cfgHLintYaml = x })
+        (view $ #cfgHLint . #cfgHLintYaml)
+        (set $ #cfgHLint . #cfgHLintYaml)
     , PU.simpleField "hlint-version"
         (error "we don't pretty print")
         parse
-        cfgHLintVersion
-        (\x cfg -> cfg { cfgHLintVersion = x })
-    -- TODO: hlint-options
+        (view $ #cfgHLint . #cfgHLintVersion)
+        (set $ #cfgHLint . #cfgHLintVersion)
+    , PU.simpleField "hlint-options"
+        (error "we don't pretty print")
+        parseOptsQ
+        (view $ #cfgHLint . #cfgHLintOptions)
+        (set $ #cfgHLint . #cfgHLintOptions)
     , PU.boolField  "doctest"
         (view $ #cfgDoctest . #cfgDoctestEnabled)
         (set $ #cfgDoctest . #cfgDoctestEnabled)
@@ -1637,11 +1662,7 @@ ghcVersionPredicate = conj . asVersionIntervals
     upper v InclusiveBound = "[ $HCNUMVER -le " ++ f v ++ " ]"
     upper v ExclusiveBound = "[ $HCNUMVER -lt " ++ f v ++ " ]"
 
-    f v =  case versionNumbers v of
-        []        -> "0"
-        [x]       -> show (x * 10000)
-        [x,y]     -> show (x * 10000 + y * 100)
-        (x:y:z:_) -> show (x * 10000 + y * 100 + z)
+    f = ghcVersionToString
 
 -------------------------------------------------------------------------------
 -- From Cabal

--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
-module Config where
+module HaskellCI.Config where
 
 import Distribution.Version
 import GHC.Generics (Generic)

--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -32,6 +32,14 @@ data ConstraintSet = ConstraintSet
 emptyConstraintSet :: String -> ConstraintSet
 emptyConstraintSet n = ConstraintSet n anyVersion []
 
+data DoctestConfig = DoctestConfig
+    { cfgDoctestEnabled  :: !Bool
+    , cfgDoctestOptions  :: [String]
+    , cfgDoctestVersion  :: !VersionRange
+    }
+  deriving (Show, Generic)
+
+-- TODO: split other blocks like DoctestConfig
 data Config = Config
     { cfgCabalInstallVersion :: Maybe Version
     , cfgHLint           :: !Bool
@@ -39,9 +47,7 @@ data Config = Config
     , cfgHLintVersion    :: !VersionRange
     , cfgHLintOptions    :: [String]
     , cfgJobs            :: (Maybe Int, Maybe Int)
-    , cfgDoctest         :: !Bool
-    , cfgDoctestOptions  :: [String]
-    , cfgDoctestVersion  :: !VersionRange
+    , cfgDoctest         :: !DoctestConfig
     , cfgLocalGhcOptions :: [String]
     , cfgConstraintSets  :: [ConstraintSet]
     , cfgCache           :: !Bool
@@ -69,9 +75,11 @@ emptyConfig = Config
     , cfgHLintVersion    = defaultHLintVersion
     , cfgHLintOptions    = []
     , cfgJobs            = (Nothing, Nothing)
-    , cfgDoctest         = False
-    , cfgDoctestOptions  = []
-    , cfgDoctestVersion  = defaultDoctestVersion
+    , cfgDoctest         = DoctestConfig
+        { cfgDoctestEnabled = False
+        , cfgDoctestOptions  = []
+        , cfgDoctestVersion  = defaultDoctestVersion
+        }
     , cfgLocalGhcOptions = []
     , cfgConstraintSets  = []
     , cfgCache           = True

--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -7,6 +7,9 @@ import GHC.Generics (Generic)
 import qualified Data.Set as S
 import qualified Data.Map as M
 
+import HaskellCI.Config.Doctest
+import HaskellCI.Config.HLint
+
 data Fold
     = FoldSDist
     | FoldUnpack
@@ -32,22 +35,12 @@ data ConstraintSet = ConstraintSet
 emptyConstraintSet :: String -> ConstraintSet
 emptyConstraintSet n = ConstraintSet n anyVersion []
 
-data DoctestConfig = DoctestConfig
-    { cfgDoctestEnabled  :: !Bool
-    , cfgDoctestOptions  :: [String]
-    , cfgDoctestVersion  :: !VersionRange
-    }
-  deriving (Show, Generic)
-
 -- TODO: split other blocks like DoctestConfig
 data Config = Config
     { cfgCabalInstallVersion :: Maybe Version
-    , cfgHLint           :: !Bool
-    , cfgHLintYaml       :: !(Maybe FilePath)
-    , cfgHLintVersion    :: !VersionRange
-    , cfgHLintOptions    :: [String]
     , cfgJobs            :: (Maybe Int, Maybe Int)
     , cfgDoctest         :: !DoctestConfig
+    , cfgHLint           :: !HLintConfig
     , cfgLocalGhcOptions :: [String]
     , cfgConstraintSets  :: [ConstraintSet]
     , cfgCache           :: !Bool
@@ -70,15 +63,18 @@ data Config = Config
 emptyConfig :: Config
 emptyConfig = Config
     { cfgCabalInstallVersion = Nothing
-    , cfgHLint           = False
-    , cfgHLintYaml       = Nothing
-    , cfgHLintVersion    = defaultHLintVersion
-    , cfgHLintOptions    = []
     , cfgJobs            = (Nothing, Nothing)
     , cfgDoctest         = DoctestConfig
         { cfgDoctestEnabled = False
-        , cfgDoctestOptions  = []
-        , cfgDoctestVersion  = defaultDoctestVersion
+        , cfgDoctestOptions = []
+        , cfgDoctestVersion = defaultDoctestVersion
+        }
+    , cfgHLint = HLintConfig
+        { cfgHLintEnabled = False
+        , cfgHLintJob     = HLintJobLatest
+        , cfgHLintYaml    = Nothing
+        , cfgHLintVersion = defaultHLintVersion
+        , cfgHLintOptions = []
         }
     , cfgLocalGhcOptions = []
     , cfgConstraintSets  = []
@@ -98,8 +94,3 @@ emptyConfig = Config
     , cfgLastInSeries    = False
     }
 
-defaultHLintVersion :: VersionRange
-defaultHLintVersion = withinVersion (mkVersion [2,1])
-
-defaultDoctestVersion :: VersionRange
-defaultDoctestVersion = withinVersion (mkVersion [0,16])

--- a/src/HaskellCI/Config/Doctest.hs
+++ b/src/HaskellCI/Config/Doctest.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE DeriveGeneric #-}
+module HaskellCI.Config.Doctest where
+
+import Distribution.Version
+import GHC.Generics (Generic)
+
+data DoctestConfig = DoctestConfig
+    { cfgDoctestEnabled :: !Bool
+    , cfgDoctestOptions :: [String]
+    , cfgDoctestVersion :: !VersionRange
+    }
+  deriving (Show, Generic)
+
+defaultDoctestVersion :: VersionRange
+defaultDoctestVersion = withinVersion (mkVersion [0,16])

--- a/src/HaskellCI/Config/HLint.hs
+++ b/src/HaskellCI/Config/HLint.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveGeneric #-}
+module HaskellCI.Config.HLint where
+
+import Distribution.Version
+import GHC.Generics (Generic)
+
+data HLintJob
+    = HLintJobLatest    -- ^ run with latest GHC
+    | HLintJob Version  -- ^ run with specified GHC version
+  deriving Show
+
+data HLintConfig = HLintConfig
+    { cfgHLintEnabled :: !Bool
+    , cfgHLintJob     :: !HLintJob
+    , cfgHLintYaml    :: !(Maybe FilePath)
+    , cfgHLintVersion :: !VersionRange
+    , cfgHLintOptions :: [String]
+    } 
+  deriving (Show, Generic)
+
+defaultHLintVersion :: VersionRange
+defaultHLintVersion = withinVersion (mkVersion [2,1])

--- a/src/HaskellCI/Glob.hs
+++ b/src/HaskellCI/Glob.hs
@@ -1,4 +1,4 @@
-module Glob where
+module HaskellCI.Glob where
 
 import Control.Applicative as App ((<$>))
 import Control.Monad (void, filterM, liftM2)

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ViewPatterns #-}
 module Main (main) where
 
-import MakeTravisYml hiding (main)
+import HaskellCI hiding (main)
 
 import Control.Applicative ((<$>), (<*>))
 import Control.Exception (ErrorCall(..), throwIO, try)


### PR DESCRIPTION
Split out `DoctestConfig`. Ideally, the relevant script parts would be generated only using `DoctestConfig`, and not as a monolith as it's currently.