### PR TITLE
Fix repository's incorrect language-classification on GitHub.com

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Fix incorrect language classification on GitHub.com
+collections/* linguist-vendored linguist-language=Cabal


### PR DESCRIPTION
Currently, GitHub classifies `haskell-ci` as a Roff repository:

<img src="https://user-images.githubusercontent.com/2346707/52713358-397faf00-2feb-11e9-9039-f5da1f667a6a.png" alt="Figure 1" />

This stems from the abundance of `collections/cabal.project.*` files with numeric suffixes, which GitHub mistakes as man pages. This PR is a small patch to correct that [using an override](https://github.com/github/linguist/blob/master/README.md#overrides).

**NOTE:** I'm *assuming* the files contained in [`collections/`](https://github.com/haskell-CI/haskell-ci/tree/master/collections) are Haskell source. If they're not, please let me know and I'll mark them as ordinary `Text`, instead of being any particular language.