### PR TITLE
Document copy-fields, and make local-ghc-options always fire

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,9 +101,9 @@ install:
   - rm -f cabal.project
   - touch cabal.project
   - "printf 'packages: \".\"\\n' >> cabal.project"
+  - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - echo 'package haskell-ci' >> cabal.project
   - "echo '  ghc-options: -Werror' >> cabal.project"
-  - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - "echo 'keep-going: False' >> cabal.project"
   - echo 'package bytestring' >> cabal.project
   - "echo '  tests: False' >> cabal.project"
@@ -132,9 +132,9 @@ script:
   - rm -f cabal.project
   - touch cabal.project
   - "printf 'packages: \"haskell-ci-*/*.cabal\"\\n' >> cabal.project"
+  - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - echo 'package haskell-ci' >> cabal.project
   - "echo '  ghc-options: -Werror' >> cabal.project"
-  - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - "echo 'keep-going: False' >> cabal.project"
   - echo 'package bytestring' >> cabal.project
   - "echo '  tests: False' >> cabal.project"

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -61,6 +61,21 @@ constraint-set deepseq-1.4
   ghc: (>= 7.8 && <7.10) || == 8.2.2
   constraints: deepseq ==1.4.*
 
+-- Copy over additional properties specified in a cabal.project file.
+-- Possible values are:
+--   none: Do not copy any properties from the cabal.project file.
+--   some: Copy a subset of the properties from the cabal.project file. (Default)
+--         The fields and sections that are copied over are:
+--
+--         * constraints
+--         * allow-newer
+--         * reorder-goals
+--         * max-backjumps
+--         * optimization
+--         * source-repository-package
+--   all: Copy every property from the cabal.project file.
+copy-fields: some
+
 -- Include these fields "as is" in generated cabal.project
 raw-project
   keep-going: False

--- a/src/HaskellCI.hs
+++ b/src/HaskellCI.hs
@@ -822,12 +822,6 @@ genTravisFromConfigs argv opts isCabalProject config prj@Project { prjPackages =
                     tellStrLns
                         [ sh $ "echo 'allow-newer: " ++ s ++ "' >> cabal.project"
                         ]
-                unless (null (cfgLocalGhcOptions config)) $ forM_ pkgs $ \Pkg{pkgName} -> do
-                    let s = unwords $ map (show . PU.showToken) $ cfgLocalGhcOptions config
-                    tellStrLns
-                        [ sh $ "echo 'package " ++ pkgName ++ "' >> cabal.project"
-                        , sh $ "echo '  ghc-options: " ++ s ++ "' >> cabal.project"
-                        ]
 
                 when (prjReorderGoals prj) $
                     tellStrLns
@@ -853,6 +847,13 @@ genTravisFromConfigs argv opts isCabalProject config prj@Project { prjPackages =
         tellStrLns
             [ sh $ "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
             ]
+
+        unless (null (cfgLocalGhcOptions config)) $ forM_ pkgs $ \Pkg{pkgName} -> do
+            let s = unwords $ map (show . PU.showToken) $ cfgLocalGhcOptions config
+            tellStrLns
+                [ sh $ "echo 'package " ++ pkgName ++ "' >> cabal.project"
+                , sh $ "echo '  ghc-options: " ++ s ++ "' >> cabal.project"
+                ]
 
         unless (null (cfgRawProject config)) $ tellStrLns
             [ sh $ "echo '" ++ l ++ "' >> cabal.project"


### PR DESCRIPTION
I attempted to use the `copy-fields` feature the other day only to realize that I have no idea how it is intended to work. This is my attempt at adding documentation for it.