### PR TITLE
Add a --version flag

### DIFF
--- a/src/HaskellCI.hs
+++ b/src/HaskellCI.hs
@@ -111,10 +111,6 @@ import HaskellCI.Project
 import HaskellCI.TestedWith
 import HaskellCI.Version
 
-#ifndef CURRENT_PACKAGE_VERSION
-#define CURRENT_PACKAGE_VERSION "???"
-#endif
-
 -------------------------------------------------------------------------------
 -- Main
 -------------------------------------------------------------------------------
@@ -348,7 +344,7 @@ genTravisFromConfigs argv opts isCabalProject config prj@Project { prjPackages =
         , "#"
         , "# For more information, see https://github.com/haskell-CI/haskell-ci"
         , "#"
-        , rawRow $ "# version: " ++ CURRENT_PACKAGE_VERSION
+        , rawRow $ "# version: " ++ haskellCIVerStr
         , "#"
         , "language: c"
         , "dist: xenial"

--- a/src/HaskellCI/Cli.hs
+++ b/src/HaskellCI/Cli.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | Most of client interface.
 module HaskellCI.Cli where
 
@@ -12,6 +14,10 @@ import qualified Options.Applicative      as O
 
 import           HaskellCI.Config
 import           HaskellCI.OptparseGrammar
+
+#ifndef CURRENT_PACKAGE_VERSION
+#define CURRENT_PACKAGE_VERSION "???"
+#endif
 
 -------------------------------------------------------------------------------
 -- Command
@@ -58,8 +64,18 @@ optionsP = Options
     <*> O.optional (O.strOption (O.long "config" <> O.metavar "CONFIGFILE" <> O.help "Configuration file"))
     <*> runOptparseGrammar configGrammar
 
+versionP :: O.Parser (a -> a)
+versionP = O.infoOption haskellCIVerStr (mconcat
+         [ O.long "version"
+         , O.short 'V'
+         , O.help "Print version information"
+         ])
+
+haskellCIVerStr :: String
+haskellCIVerStr = CURRENT_PACKAGE_VERSION
+
 cliParserInfo :: O.ParserInfo (Command, Options)
-cliParserInfo = O.info ((,) <$> cmdP <*> optionsP O.<**> O.helper) $ mconcat
+cliParserInfo = O.info ((,) <$> cmdP <*> optionsP O.<**> versionP O.<**> O.helper) $ mconcat
     [ O.fullDesc
     , O.header "haskell-ci - generate CI scripts for Haskell projects"
     ]
@@ -68,7 +84,7 @@ cliParserInfo = O.info ((,) <$> cmdP <*> optionsP O.<**> O.helper) $ mconcat
         [ O.command "regenerate"  $ O.info (pure CommandRegenerate) $ O.progDesc "Regenerate .travis.yml"
         , O.command "travis"      $ O.info travisP                  $ O.progDesc "Generate travis-ci config"
         , O.command "list-ghc"    $ O.info (pure CommandListGHC)    $ O.progDesc "List known GHC versions"
-        , O.command "dump-config" $ O.info (pure CommandDumpConfig) $ O.progDesc "Dump cabal.haskell-ci config with default values" 
+        , O.command "dump-config" $ O.info (pure CommandDumpConfig) $ O.progDesc "Dump cabal.haskell-ci config with default values"
         ]) <|> travisP
 
     travisP = CommandTravis


### PR DESCRIPTION
Currently, there's not a simple way to quickly ascertain the `haskell-ci` version. This adds `--version`, which prints out what you would expect.