### PR TITLE
Fix #182 and #236

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ script:
 
   # build & run tests, build benchmarks
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all
 
   # doctest
   - (cd haskell-ci-* && doctest --fast -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable src)
@@ -164,11 +164,12 @@ script:
 
   # Constraint sets
   - rm -rf cabal.project.local
-
   # Constraint set deepseq-1.4
   - echo Constraint set deepseq-1.4 && echo -en 'travis_fold:start:constraint-sets-deepseq-1.4\\r'
-  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then ${CABAL} new-build -w ${HC} --disable-tests --disable-benchmarks  --constraint='deepseq ==1.4.*' all ; fi
-
+  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then CSTEST=--disable-tests ; fi
+  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then CSBENCH=--disable-benchmarks ; fi
+  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then ${CABAL} v2-build -w ${HC} ${CSTEST} ${CSBENCH} all  --constraint='deepseq ==1.4.*' ; fi
+  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then ${CABAL} v2-haddock -w ${HC} ${CSTEST} ${CSBENCH} all  --constraint='deepseq ==1.4.*' ; fi
   - echo -en 'travis_fold:end:constraint-sets-deepseq-1.4\\r'
 
 # REGENDATA ["--output=.travis.yml","--config=cabal.haskell-ci","haskell-ci.cabal"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,10 +166,8 @@ script:
   - rm -rf cabal.project.local
   # Constraint set deepseq-1.4
   - echo Constraint set deepseq-1.4 && echo -en 'travis_fold:start:constraint-sets-deepseq-1.4\\r'
-  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then CSTEST=--disable-tests ; fi
-  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then CSBENCH=--disable-benchmarks ; fi
-  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then ${CABAL} v2-build -w ${HC} ${CSTEST} ${CSBENCH} all  --constraint='deepseq ==1.4.*' ; fi
-  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then ${CABAL} v2-haddock -w ${HC} ${CSTEST} ${CSBENCH} all  --constraint='deepseq ==1.4.*' ; fi
+  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then ${CABAL} v2-build -w ${HC} --disable-tests --disable-benchmarks --constraint='deepseq ==1.4.*' --constraint='binary installed' all ; fi
+  - if [ $HCNUMVER -ge 70800 ] && [ $HCNUMVER -lt 71000 ]  ||  [ $HCNUMVER -eq 80202 ] ; then ${CABAL} v2-haddock -w ${HC} --disable-tests --disable-benchmarks --constraint='deepseq ==1.4.*' --constraint='binary installed' all ; fi
   - echo -en 'travis_fold:end:constraint-sets-deepseq-1.4\\r'
 
 # REGENDATA ["--output=.travis.yml","--config=cabal.haskell-ci","haskell-ci.cabal"]

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -73,6 +73,7 @@ osx: 8.4.4
 constraint-set deepseq-1.4
   ghc: (>= 7.8 && <7.10) || == 8.2.2
   constraints: deepseq ==1.4.*
+  constraints: binary installed
 
   -- Constraint sets accept booleans for few steps, as the main script
   -- Defaults are False.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -12,6 +12,19 @@ ghc-head: True
 -- remove cabal noise from test output
 -- cabal-noise: False
 
+-- Build tests. In addition to True and False you may specify
+-- a version range, e.g. >= 8.0 to build tests only in some jobs.
+tests: True
+
+-- Run tests. Note that only built tests are run. Accepts booleans or version range.
+run-tests: True
+
+-- Build benchmarks. There are no way to run benchmarks. Accepts booleans or version range.
+benchmarks: True
+
+-- Build haddocks. Accepts booleans or version range.
+haddock: True
+
 -- Run cabal check
 -- cabal-check: True
 
@@ -60,6 +73,11 @@ osx: 8.4.4
 constraint-set deepseq-1.4
   ghc: (>= 7.8 && <7.10) || == 8.2.2
   constraints: deepseq ==1.4.*
+
+  -- Constraint sets accept booleans for few steps, as the main script
+  -- Defaults are False.
+  -- These fields don't accept version ranges: you should rather create
+  -- another constraint set.
 
   -- tests: False
   -- run-tests: False

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -61,6 +61,11 @@ constraint-set deepseq-1.4
   ghc: (>= 7.8 && <7.10) || == 8.2.2
   constraints: deepseq ==1.4.*
 
+  -- tests: False
+  -- run-tests: False
+  -- benchmarks: False
+  haddock: True
+
 -- Copy over additional properties specified in a cabal.project file.
 -- Possible values are:
 --   none: Do not copy any properties from the cabal.project file.

--- a/fixtures/cabal.project.copy-fields.all.travis.yml
+++ b/fixtures/cabal.project.copy-fields.all.travis.yml
@@ -148,7 +148,7 @@ script:
 
   # build & run tests, build benchmarks
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all
 
   # cabal check
   - (cd servant-* && ${CABAL} check)

--- a/fixtures/cabal.project.copy-fields.none.travis.yml
+++ b/fixtures/cabal.project.copy-fields.none.travis.yml
@@ -138,7 +138,7 @@ script:
 
   # build & run tests, build benchmarks
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all
 
   # cabal check
   - (cd servant-* && ${CABAL} check)

--- a/fixtures/cabal.project.copy-fields.some.travis.yml
+++ b/fixtures/cabal.project.copy-fields.some.travis.yml
@@ -144,7 +144,7 @@ script:
 
   # build & run tests, build benchmarks
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all
 
   # cabal check
   - (cd servant-* && ${CABAL} check)

--- a/fixtures/cabal.project.empty-line.travis.yml
+++ b/fixtures/cabal.project.empty-line.travis.yml
@@ -168,7 +168,7 @@ script:
 
   # build & run tests, build benchmarks
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all
 
   # cabal check
   - (cd servant-* && ${CABAL} check)

--- a/fixtures/cabal.project.messy.travis.yml
+++ b/fixtures/cabal.project.messy.travis.yml
@@ -162,7 +162,7 @@ script:
 
   # build & run tests, build benchmarks
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - ${CABAL} new-test -w ${HC} ${TEST} ${BENCH} all
 
   # cabal check
   - (cd servant-* && ${CABAL} check)

--- a/src/HaskellCI.hs
+++ b/src/HaskellCI.hs
@@ -964,7 +964,7 @@ doctestJobVersionRange = orLaterVersion $ mkVersion [8,0]
 -- /Note:/ same argument work for hlint too, but not exactly
 --
 doctestArgs :: GenericPackageDescription -> [[String]]
-doctestArgs gpd =
+doctestArgs gpd = nub $
     [ libraryModuleArgs c
     | c <- flattenPackageDescription gpd ^.. L.library . traverse
     ] ++
@@ -1010,7 +1010,7 @@ hlintJobVersionRange vs HLintJobLatest = case S.maxView vs of
 hlintJobVersionRange _ (HLintJob v)   = thisVersion v
 
 hlintArgs :: GenericPackageDescription -> [[String]]
-hlintArgs gpd =
+hlintArgs gpd = nub $
     [ libraryModuleArgs c
     | c <- flattenPackageDescription gpd ^.. L.library . traverse
     ] ++

--- a/src/HaskellCI.hs
+++ b/src/HaskellCI.hs
@@ -749,17 +749,18 @@ genTravisFromConfigs argv opts isCabalProject config prj@Project { prjPackages =
             tellStrLns [ comment $ "Constraint set " ++ name ]
 
             let shForCs = shForJob versions' (csGhcVersions cs)
-            let constraintFlags = concatMap (\x ->  " --constraint='" ++ x ++ "'") (csConstraints cs)
+            let testFlag = if csTests cs then "--enable-tests" else "--disable-tests"
+            let benchFlag = if csBenchmarks cs then "--enable-benchmarks" else "--disable-benchmarks"
+            let constraintFlags = map (\x ->  "--constraint='" ++ x ++ "'") (csConstraints cs)
+            let allFlags = unwords (testFlag : benchFlag : constraintFlags)
 
             foldedTellStrLns' FoldConstraintSets name ("Constraint set " ++ name) folds $ tellStrLns
-                [ shForCs $ "CSTEST=" ++ if csTests cs then "--enable-tests" else "--disable-tests"
-                , shForCs $ "CSBENCH=" ++ if csBenchmarks cs then "--enable-benchmarks" else "--disable-benchmarks"
-                , shForCs $ "${CABAL} v2-build -w ${HC} ${CSTEST} ${CSBENCH} all " ++ constraintFlags
+                [ shForCs $ "${CABAL} v2-build -w ${HC} " ++ allFlags ++ " all"
                 , if csRunTests cs
-                  then shForCs $ "${CABAL} v2-test -w ${HC} ${CSTEST} ${CSBENCH} all " ++ constraintFlags
+                  then shForCs $ "${CABAL} v2-test -w ${HC} " ++ allFlags ++ " all"
                   else RowSkip
                 , if csHaddock cs
-                  then shForCs $ "${CABAL} v2-haddock -w ${HC} ${CSTEST} ${CSBENCH} all " ++ constraintFlags
+                  then shForCs $ "${CABAL} v2-haddock -w ${HC} " ++ allFlags ++ " all"
                   else RowSkip
                 ]
         tellStrLns [""]

--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -55,6 +55,7 @@ data Config = Config
     , cfgInstallDeps         :: !Bool
     , cfgInstalled           :: [Installed]
     , cfgTests               :: !VersionRange
+    , cfgRunTests            :: !VersionRange
     , cfgBenchmarks          :: !VersionRange
     , cfgHaddock             :: !VersionRange
     , cfgNoTestsNoBench      :: !VersionRange
@@ -106,6 +107,7 @@ emptyConfig = Config
     , cfgInstalled       = []
     , cfgInstallDeps     = True
     , cfgTests           = anyVersion
+    , cfgRunTests        = anyVersion
     , cfgBenchmarks      = anyVersion
     , cfgHaddock         = anyVersion
     , cfgNoTestsNoBench  = anyVersion
@@ -152,7 +154,9 @@ configGrammar = Config
     <*> C.monoidalFieldAla    "installed"                 (C.alaList C.FSep)                  #cfgInstalled
         ^^^ metahelp "+/-PKG" "Specify 'constraint: ... installed' packages"
     <*> rangeField            "tests"                                                         #cfgTests anyVersion
-        ^^^ metahelp "RANGE" "Build and run tests with"
+        ^^^ metahelp "RANGE" "Build tests with"
+    <*> rangeField            "run-tests"                                                     #cfgRunTests anyVersion
+        ^^^ metahelp "RANGE" "Run tests with (note: only built tests are run)"
     <*> rangeField           "benchmarks"                                                     #cfgBenchmarks anyVersion
         ^^^ metahelp "RANGE" "Build benchmarks"
     <*> rangeField           "haddock"                                                        #cfgHaddock anyVersion

--- a/src/HaskellCI/Config/ConstraintSet.hs
+++ b/src/HaskellCI/Config/ConstraintSet.hs
@@ -15,12 +15,15 @@ data ConstraintSet = ConstraintSet
     { csName        :: String
     , csGhcVersions :: VersionRange
     , csConstraints :: [String] -- we parse these simply as strings
+    , csTests       :: Bool
     , csRunTests    :: Bool
+    , csBenchmarks  :: Bool
+    , csHaddock     :: Bool
     }
   deriving (Show, Generic)
 
 emptyConstraintSet :: String -> ConstraintSet
-emptyConstraintSet n = ConstraintSet n anyVersion [] False
+emptyConstraintSet n = ConstraintSet n anyVersion [] False False False False
 
 -------------------------------------------------------------------------------
 -- Grammar
@@ -32,4 +35,7 @@ constraintSetGrammar
 constraintSetGrammar name = ConstraintSet name
     <$> C.optionalFieldDef "ghc"                                           #csGhcVersions anyVersion
     <*> C.monoidalFieldAla "constraints" (C.alaList' C.CommaVCat NoCommas) #csConstraints
+    <*> C.booleanFieldDef  "tests"                                         #csTests False
     <*> C.booleanFieldDef  "run-tests"                                     #csRunTests False
+    <*> C.booleanFieldDef  "benchmarks"                                    #csBenchmarks False
+    <*> C.booleanFieldDef  "haddock"                                       #csHaddock False


### PR DESCRIPTION
- Add global --run-tests/--no-run-tests/--run-tests-jobs to specify
  when we actually run tests (maybe less then what we build!)

- Add steps configuration to constraint sets:
  - tests
  - run-tests
  - benchmarks
  - haddock
  - these are only booleans for now, if you need more control, make
    another constraint set!

---

cc @RyanGlScott 