### PR TITLE
Remove unneeded --dry flag from new-freeze invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ install:
   - cat cabal.project.local || true
   - if [ -f "./configure.ac" ]; then (cd "." && autoreconf -i); fi
   - rm -f cabal.project.freeze
-  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH} --dry
+  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH}
   - "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
   - rm  cabal.project.freeze
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all

--- a/fixtures/cabal.project.copy-fields.all.travis.yml
+++ b/fixtures/cabal.project.copy-fields.all.travis.yml
@@ -111,7 +111,7 @@ install:
   - if [ -f "servant-docs/configure.ac" ]; then (cd "servant-docs" && autoreconf -i); fi
   - if [ -f "servant-server/configure.ac" ]; then (cd "servant-server" && autoreconf -i); fi
   - rm -f cabal.project.freeze
-  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH} --dry
+  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH}
   - "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
   - rm  cabal.project.freeze
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all

--- a/fixtures/cabal.project.copy-fields.none.travis.yml
+++ b/fixtures/cabal.project.copy-fields.none.travis.yml
@@ -106,7 +106,7 @@ install:
   - if [ -f "servant-docs/configure.ac" ]; then (cd "servant-docs" && autoreconf -i); fi
   - if [ -f "servant-server/configure.ac" ]; then (cd "servant-server" && autoreconf -i); fi
   - rm -f cabal.project.freeze
-  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH} --dry
+  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH}
   - "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
   - rm  cabal.project.freeze
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all

--- a/fixtures/cabal.project.copy-fields.some.travis.yml
+++ b/fixtures/cabal.project.copy-fields.some.travis.yml
@@ -109,7 +109,7 @@ install:
   - if [ -f "servant-docs/configure.ac" ]; then (cd "servant-docs" && autoreconf -i); fi
   - if [ -f "servant-server/configure.ac" ]; then (cd "servant-server" && autoreconf -i); fi
   - rm -f cabal.project.freeze
-  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH} --dry
+  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH}
   - "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
   - rm  cabal.project.freeze
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all

--- a/fixtures/cabal.project.empty-line.travis.yml
+++ b/fixtures/cabal.project.empty-line.travis.yml
@@ -133,7 +133,7 @@ install:
   - if [ -f "servant-docs/configure.ac" ]; then (cd "servant-docs" && autoreconf -i); fi
   - if [ -f "servant-server/configure.ac" ]; then (cd "servant-server" && autoreconf -i); fi
   - rm -f cabal.project.freeze
-  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH} --dry
+  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH}
   - "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
   - rm  cabal.project.freeze
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all

--- a/fixtures/cabal.project.messy.travis.yml
+++ b/fixtures/cabal.project.messy.travis.yml
@@ -130,7 +130,7 @@ install:
   - if [ -f "servant-docs/configure.ac" ]; then (cd "servant-docs" && autoreconf -i); fi
   - if [ -f "servant-server/configure.ac" ]; then (cd "servant-server" && autoreconf -i); fi
   - rm -f cabal.project.freeze
-  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH} --dry
+  - ${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH}
   - "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
   - rm  cabal.project.freeze
   - ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all

--- a/src/HaskellCI.hs
+++ b/src/HaskellCI.hs
@@ -572,7 +572,7 @@ genTravisFromConfigs argv config prj@Project { prjPackages = pkgs } versions' = 
     when (cfgInstallDeps config) $ do
         tellStrLns
             -- dump install plan
-            [ sh $ "${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH} --dry"
+            [ sh $ "${CABAL} new-freeze -w ${HC} ${TEST} ${BENCH}"
             , sh $ "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
             , sh $ "rm  cabal.project.freeze"
 


### PR DESCRIPTION
As far as I can tell, the `--dry` flag does not do anything in the context of `new-freeze`.