### PR TITLE
Add env example in cabal.haskell-ci

### DIFF
--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -66,6 +66,10 @@ doctest-options: --fast
 -- macOS job
 osx: 8.4.4
 
+-- Define per-job environment variables
+-- env: 8.4.4:FOO=bar,
+--      8.6.4:FOO=baz
+
 -- Constraint sets
 -- Package will be build with different constraints.
 -- This is useful to check compatibility with older versions of dependencies.


### PR DESCRIPTION
I recently found myself wondering how to use `env` in a `cabal.haskell-ci` file, but couldn't find any examples of how to do so. This patch adds such an example to this repo's `cabal.haskell-ci` file as a demo.