### PR TITLE
Support ShellCheck 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ before_install:
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
   - CABAL="$CABAL -vnormal+nowrap+markoutput"
-  - set -o pipefail
   - |
     echo 'function blue(s) { printf "\033[0;34m" s "\033[0m " }'           >> .colorful.awk
     echo 'BEGIN { state = "output"; }'                                     >> .colorful.awk

--- a/fixtures/cabal.project.copy-fields.all.travis.yml
+++ b/fixtures/cabal.project.copy-fields.all.travis.yml
@@ -77,7 +77,6 @@ before_install:
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
   - CABAL="$CABAL -vnormal+nowrap+markoutput"
-  - set -o pipefail
   - |
     echo 'function blue(s) { printf "\033[0;34m" s "\033[0m " }'           >> .colorful.awk
     echo 'BEGIN { state = "output"; }'                                     >> .colorful.awk

--- a/fixtures/cabal.project.copy-fields.none.travis.yml
+++ b/fixtures/cabal.project.copy-fields.none.travis.yml
@@ -77,7 +77,6 @@ before_install:
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
   - CABAL="$CABAL -vnormal+nowrap+markoutput"
-  - set -o pipefail
   - |
     echo 'function blue(s) { printf "\033[0;34m" s "\033[0m " }'           >> .colorful.awk
     echo 'BEGIN { state = "output"; }'                                     >> .colorful.awk

--- a/fixtures/cabal.project.copy-fields.some.travis.yml
+++ b/fixtures/cabal.project.copy-fields.some.travis.yml
@@ -77,7 +77,6 @@ before_install:
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
   - CABAL="$CABAL -vnormal+nowrap+markoutput"
-  - set -o pipefail
   - |
     echo 'function blue(s) { printf "\033[0;34m" s "\033[0m " }'           >> .colorful.awk
     echo 'BEGIN { state = "output"; }'                                     >> .colorful.awk

--- a/fixtures/cabal.project.empty-line.travis.yml
+++ b/fixtures/cabal.project.empty-line.travis.yml
@@ -82,7 +82,6 @@ before_install:
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
   - CABAL="$CABAL -vnormal+nowrap+markoutput"
-  - set -o pipefail
   - |
     echo 'function blue(s) { printf "\033[0;34m" s "\033[0m " }'           >> .colorful.awk
     echo 'BEGIN { state = "output"; }'                                     >> .colorful.awk

--- a/fixtures/cabal.project.messy.travis.yml
+++ b/fixtures/cabal.project.messy.travis.yml
@@ -82,7 +82,6 @@ before_install:
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
   - CABAL="$CABAL -vnormal+nowrap+markoutput"
-  - set -o pipefail
   - |
     echo 'function blue(s) { printf "\033[0;34m" s "\033[0m " }'           >> .colorful.awk
     echo 'BEGIN { state = "output"; }'                                     >> .colorful.awk

--- a/fixtures/cabal.project.travis-patch.travis.yml
+++ b/fixtures/cabal.project.travis-patch.travis.yml
@@ -77,7 +77,6 @@ before_install:
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
   - CABAL="$CABAL -vnormal+nowrap+markoutput"
-  - set -o pipefail
   - |
     echo 'function blue(s) { printf "\033[0;34m" s "\033[0m " }'           >> .colorful.awk
     echo 'BEGIN { state = "output"; }'                                     >> .colorful.awk

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -166,7 +166,7 @@ library haskell-ci-internal
 
   -- ShellCheck. Would need newer transformers for older GHC
   if (flag(shellcheck) && impl(ghc >=7.10 && <8.7))
-    build-depends: ShellCheck ==0.6.0
+    build-depends: ShellCheck ==0.7.0
 
 executable haskell-ci
   main-is:          Main.hs

--- a/src/HaskellCI/Sh.hs
+++ b/src/HaskellCI/Sh.hs
@@ -129,7 +129,7 @@ instance MonadSh ShM where
             ]
       where
         res = runIdentity $ checkScript iface spec
-        iface = SC.SystemInterface $ \n -> return $ Left $ "cannot read file: " ++ n
+        iface = SC.mockedSystemInterface []
         spec  = SC.emptyCheckSpec
             { SC.csFilename          = "stdin"
             , SC.csScript            = cmd

--- a/src/HaskellCI/Travis.hs
+++ b/src/HaskellCI/Travis.hs
@@ -124,7 +124,6 @@ makeTravis argv Config {..} prj JobVersions {..} = do
         sh "CABAL=\"$CABAL -vnormal+nowrap+markoutput\""
 
         -- Color cabal output
-        sh "set -o pipefail"
         when cfgColor $ do
             cat' ".colorful.awk"
                 [ "function blue(s) { printf \"\\033[0;34m\" s \"\\033[0m \" }"


### PR DESCRIPTION
ShellCheck 0.7.x complains about use of "set -o pipefail" and issues an error,
saying:

    SC2039: In POSIX sh, set option pipefail is undefined.

We can (a) drop the shell command or (b) annotate it to silence ShellCheck.
I've opted for solution (a) since ShellCheck seems to have a point here.
