### PR TITLE
GHC 8.8.1 has been released

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ At time of writing [Travis-CI](https://travis-ci.org/) has [support for building
  - GHC 8.2.1, GHC 8.2.2
  - GHC 8.4.1, GHC 8.4.2, GHC 8.4.3, GHC 8.4.4
  - GHC 8.6.1, GHC 8.6.2, GHC 8.6.3, GHC 8.6.4, GHC 8.6.5
- - GHC 8.8.1 *(pre-release)*
+ - GHC 8.8.1
  - GHC HEAD.
 
 Each GHC version is provided in a separate `ghc-<version>` `.deb` package installing into `/opt/ghc/<version>` (thus allowing to be installed at the same time if needed) published in a [PPA](https://launchpad.net/~hvr/+archive/ghc). The easiest way to "activate" a particular GHC version is to prepend its `bin`-folder to the `$PATH` environment variable (see example in next section).


### PR DESCRIPTION
GHC 8.8.1 was released almost two months ago. It is supported by the HEAD version of this library, but not yet by the Hackage version. In `README.md` please remove the "pre-release" tag from GHC 8.8.1, and then upload a new version to Hackage. Thanks.