### PR TITLE
apt sources accept sourcelines now

### DIFF
--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.7.20191105
+version:            0.7.20191106
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.

--- a/src/HaskellCI/Compiler.hs
+++ b/src/HaskellCI/Compiler.hs
@@ -4,6 +4,7 @@ module HaskellCI.Compiler (
     CompilerVersion (..),
     maybeGHC,
     isGHCJS,
+    maybeGHCJS,
     previewGHC,
     -- * Compiler version range
     CompilerRange (..),
@@ -46,6 +47,10 @@ maybeGHC x _ _       = x
 isGHCJS :: CompilerVersion -> Bool
 isGHCJS (GHCJS _) = True
 isGHCJS _         = False
+
+maybeGHCJS :: CompilerVersion -> Maybe Version
+maybeGHCJS (GHCJS v) = Just v
+maybeGHCJS _         = Nothing
 
 -------------------------------------------------------------------------------
 -- CompilerRange

--- a/src/HaskellCI/Travis/Yaml.hs
+++ b/src/HaskellCI/Travis/Yaml.hs
@@ -85,8 +85,13 @@ data TravisAddons = TravisAddons
 
 data TravisApt = TravisApt
     { taPackages :: [String]
-    , taSources  :: [String]
+    , taSources  :: [TravisAptSource]
     }
+  deriving Show
+
+data TravisAptSource
+    = TravisAptSource String
+    | TravisAptSourceLine String (Maybe String) -- ^ sourceline with optional key
   deriving Show
 
 newtype TravisAllowFailure = TravisAllowFailure
@@ -232,4 +237,14 @@ instance Aeson.ToJSON TravisApt where
     toJSON TravisApt {..} = Aeson.object
         [ "packages" Aeson..= taPackages
         , "sources"  Aeson..= taSources
+        ]
+
+instance Aeson.ToJSON TravisAptSource where
+    toJSON (TravisAptSource s) = Aeson.toJSON s
+    toJSON (TravisAptSourceLine sl Nothing) = Aeson.object
+        [ "sourceline" Aeson..= sl
+        ]
+    toJSON (TravisAptSourceLine sl (Just key_url)) = Aeson.object
+        [ "sourceline" Aeson..= sl
+        , "key_url"    Aeson..= key_url
         ]


### PR DESCRIPTION
Which allows to install GHCJS stuff using `apt` already.
Also bionic works now.