### PR TITLE
WIP: Resolve #294. Use install --ignore-project to install tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ install:
   - cat $CABALHOME/config
   - rm -fv cabal.project cabal.project.local cabal.project.freeze
   - travis_retry ${CABAL} v2-update -v
-  - (cd /tmp && ${CABAL} v2-install $WITHCOMPILER -j2 doctest --constraint='doctest ==0.16.*' | color_cabal_output)
+  - ${CABAL} v2-install --ignore-project $WITHCOMPILER -j2 doctest --constraint='doctest ==0.16.*' | color_cabal_output
   - if [ $HCNUMVER -ge 80800 ] && [ $HCNUMVER -lt 81000 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $WITHCOMPILER --dry-run hlint  --constraint='hlint ==2.2.*' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
   - "if [ $HCNUMVER -ge 80800 ] && [ $HCNUMVER -lt 81000 ] ; then if [ ! -e $HOME/.hlint/hlint-$HLINTVER/hlint ]; then echo \"Downloading HLint version $HLINTVER\"; mkdir -p $HOME/.hlint; curl --write-out 'Status Code: %{http_code} Redirects: %{num_redirects} Total time: %{time_total} Total Dsize: %{size_download}\\n' --silent --location --output $HOME/.hlint/hlint-$HLINTVER.tar.gz \"https://github.com/ndmitchell/hlint/releases/download/v$HLINTVER/hlint-$HLINTVER-x86_64-linux.tar.gz\"; tar -xzv -f $HOME/.hlint/hlint-$HLINTVER.tar.gz -C $HOME/.hlint; fi ; fi"
   - if [ $HCNUMVER -ge 80800 ] && [ $HCNUMVER -lt 81000 ] ; then mkdir -p $CABALHOME/bin && ln -sf "$HOME/.hlint/hlint-$HLINTVER/hlint" $CABALHOME/bin/hlint ; fi

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.9.20191213
+version:            0.9.20191215
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.

--- a/src/HaskellCI/Travis.hs
+++ b/src/HaskellCI/Travis.hs
@@ -253,7 +253,7 @@ makeTravis argv Config {..} prj JobVersions {..} = do
                 | otherwise = " --constraint='doctest " ++ C.prettyShow (cfgDoctestVersion cfgDoctest) ++ "'"
         when doctestEnabled $
             shForJob (Range (cfgDoctestEnabled cfgDoctest) /\ doctestJobVersionRange) $
-                cabalInTmp $ "v2-install $WITHCOMPILER -j2 doctest" ++ doctestVersionConstraint
+                cabal $ "v2-install --ignore-project $WITHCOMPILER -j2 doctest" ++ doctestVersionConstraint
 
         -- Install hlint
         let hlintVersionConstraint
@@ -276,15 +276,15 @@ makeTravis argv Config {..} prj JobVersions {..} = do
                 forHLint "mkdir -p $CABALHOME/bin && ln -sf \"$HOME/.hlint/hlint-$HLINTVER/hlint\" $CABALHOME/bin/hlint"
                 forHLint "hlint --version"
 
-            else forHLint $ cabalInTmp $ "v2-install $WITHCOMPILER -j2 hlint" ++ hlintVersionConstraint
+            else forHLint $ cabal $ "v2-install --ignore-project $WITHCOMPILER -j2 hlint" ++ hlintVersionConstraint
 
         -- Install cabal-plan (for ghcjs tests)
         when (anyGHCJS && cfgGhcjsTests) $ do
-            shForJob RangeGHCJS $ cabalInTmp "v2-install -w ghc-8.4.4 cabal-plan --constraint='cabal-plan ^>=0.6.0.0' --constraint='cabal-plan +exe'"
+            shForJob RangeGHCJS $ cabal "v2-install --ignore-project -w ghc-8.4.4 cabal-plan --constraint='cabal-plan ^>=0.6.0.0' --constraint='cabal-plan +exe'"
 
         -- Install happy
         when anyGHCJS $ for_ cfgGhcjsTools $ \t ->
-            shForJob RangeGHCJS $ cabalInTmp $ "v2-install -w ghc-8.4.4 " ++ C.prettyShow t
+            shForJob RangeGHCJS $ cabal $ "v2-install --ignore-project -w ghc-8.4.4 " ++ C.prettyShow t
 
         -- create cabal.project file
         generateCabalProject False
@@ -591,9 +591,6 @@ makeTravis argv Config {..} prj JobVersions {..} = do
               | otherwise = cabalCmd
       where
         cabalCmd = "${CABAL} " ++ cmd
-
-    cabalInTmp :: String -> String
-    cabalInTmp cmd = "(cd /tmp && " ++ cabal cmd ++ ")"
 
     forJob :: CompilerRange -> String -> Maybe String
     forJob vr cmd


### PR DESCRIPTION
WIP, as this should fail on OSX jobs; that `cabal-install` is not yet updated to `cabal-install-3.0.1.0-rc2`