### PR TITLE
Rename prjOrigFields to prjOtherFields, change parseProject's semantics

### DIFF
--- a/cabal-install-parsers/Changelog.md
+++ b/cabal-install-parsers/Changelog.md
@@ -1,6 +1,12 @@
-## 0.2.1
+## 0.3
 
-Add `NFData` instances
+- Rename `prjOrigFields` to `prjOtherFields` to reflect its intended purpose:
+  contain all fields of a `cabal.project` file that are not already covered by
+  a different field of `Project`, such as `prjPackages`, `prjOptPackages`,
+  `prjSourceRepos`, etc. The semantics of `parseProject` have also been changed
+  accordingly, so `Project`s produced by `parseProject` will no longer have
+  `prjOtherFields` entries that overlap with other `Project` fields.
+- Add `NFData` instances
 
 ## 0.2
 

--- a/cabal-install-parsers/cabal-install-parsers.cabal
+++ b/cabal-install-parsers/cabal-install-parsers.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cabal-install-parsers
-version:            0.2.1
+version:            0.3
 synopsis:           Utilities to work with cabal-install files
 description:
   @cabal-install-parsers@ provides parsers for @cabal-install@ files:
@@ -109,6 +109,7 @@ test-suite cabal-parsers-golden
     , containers
     , directory
     , filepath
+    , pretty
 
   -- dependencies needing explicit constraints
   build-depends:

--- a/cabal-install-parsers/fixtures/haskell-ci.golden
+++ b/cabal-install-parsers/fixtures/haskell-ci.golden
@@ -2,9 +2,15 @@ Project
   {prjAllowNewer = [],
    prjConstraints = [],
    prjMaxBackjumps = Nothing,
-   prjOptPackages = [],
+   prjOptPackages = ["cabal-parsers"],
    prjOptimization = OptimizationOn,
-   prjPackages = [".", "cabal-parsers"],
+   prjOtherFields = [PrettyField "tests" "true",
+                     PrettySection
+                       "package"
+                       ["haskell-ci"]
+                       [PrettyField "ghc-options" "-Wall",
+                        PrettyField "ghc-options" "-Werror"]],
+   prjPackages = ["."],
    prjReorderGoals = False,
    prjSourceRepos = [],
    prjUriPackages = []}

--- a/cabal-install-parsers/fixtures/haskell-ci.project
+++ b/cabal-install-parsers/fixtures/haskell-ci.project
@@ -2,7 +2,7 @@
 -- Consult http://cabal.readthedocs.io/en/latest/nix-local-build.html for more information
 
 packages: .
-packages: cabal-parsers
+optional-packages: cabal-parsers
 
 tests: true
 

--- a/fixtures/cabal.project.copy-fields.all.travis.yml
+++ b/fixtures/cabal.project.copy-fields.all.travis.yml
@@ -165,12 +165,12 @@ install:
     echo "packages: servant-docs" >> cabal.project
     echo "packages: servant-server" >> cabal.project
   - |
-    echo "package servant"                         >> cabal.project
-    echo "  tests: False"                          >> cabal.project
-    echo ""                                        >> cabal.project
     echo "constraints: foundation >= 0.14"         >> cabal.project
     echo "allow-newer: servant-js:servant"         >> cabal.project
     echo "allow-newer: servant-js:servant-foreign" >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant"                         >> cabal.project
+    echo "  tests: False"                          >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -205,12 +205,12 @@ script:
     echo "packages: ${PKGDIR_servant_docs}" >> cabal.project
     echo "packages: ${PKGDIR_servant_server}" >> cabal.project
   - |
-    echo "package servant"                         >> cabal.project
-    echo "  tests: False"                          >> cabal.project
-    echo ""                                        >> cabal.project
     echo "constraints: foundation >= 0.14"         >> cabal.project
     echo "allow-newer: servant-js:servant"         >> cabal.project
     echo "allow-newer: servant-js:servant-foreign" >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant"                         >> cabal.project
+    echo "  tests: False"                          >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.9.20200306
+version:            0.9.20200321
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.
@@ -154,7 +154,7 @@ library haskell-ci-internal
   build-depends:
     , aeson                 ^>=1.4.2.0
     , base-compat           ^>=0.11
-    , cabal-install-parsers ^>=0.1 || ^>=0.2
+    , cabal-install-parsers ^>=0.3
     , exceptions            ^>=0.10.0
     , generic-lens-lite     ^>=0.1
     , HsYAML                ^>=0.2.0.0


### PR DESCRIPTION
This changes the semantics of `Project`'s `prjOtherFields` (previously `prjOrigFields`) to reflect its intended purpose of being a catch-all field for everything that is not already covered by an existing field of `Project`. I've tweaked golden test in `cabal-parsers-golden` to ensure that these semantics are being upheld by `parseProject`.

Fixes #367.