### PR TITLE
Add -Werror=missing-methods to local packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,18 +125,18 @@ install:
     echo "packages: ." >> cabal.project
     echo "packages: cabal-install-parsers" >> cabal.project
   - |
-    echo "allow-newer: HsYAML:base"      >> cabal.project
-    echo ""                              >> cabal.project
-    echo "package haskell-ci"            >> cabal.project
-    echo "  ghc-options: -Werror"        >> cabal.project
-    echo ""                              >> cabal.project
-    echo "package cabal-install-parsers" >> cabal.project
-    echo "  ghc-options: -Werror"        >> cabal.project
-    echo ""                              >> cabal.project
-    echo "keep-going:  False"            >> cabal.project
-    echo ""                              >> cabal.project
-    echo "package bytestring"            >> cabal.project
-    echo "  tests: False"                >> cabal.project
+    echo "allow-newer: HsYAML:base"                       >> cabal.project
+    echo ""                                               >> cabal.project
+    echo "package haskell-ci"                             >> cabal.project
+    echo "  ghc-options: -Werror -Werror=missing-methods" >> cabal.project
+    echo ""                                               >> cabal.project
+    echo "package cabal-install-parsers"                  >> cabal.project
+    echo "  ghc-options: -Werror -Werror=missing-methods" >> cabal.project
+    echo ""                                               >> cabal.project
+    echo "keep-going:  False"                             >> cabal.project
+    echo ""                                               >> cabal.project
+    echo "package bytestring"                             >> cabal.project
+    echo "  tests: False"                                 >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(Cabal|cabal-install-parsers|haskell-ci)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -165,18 +165,18 @@ script:
     echo "packages: ${PKGDIR_haskell_ci}" >> cabal.project
     echo "packages: ${PKGDIR_cabal_install_parsers}" >> cabal.project
   - |
-    echo "allow-newer: HsYAML:base"      >> cabal.project
-    echo ""                              >> cabal.project
-    echo "package haskell-ci"            >> cabal.project
-    echo "  ghc-options: -Werror"        >> cabal.project
-    echo ""                              >> cabal.project
-    echo "package cabal-install-parsers" >> cabal.project
-    echo "  ghc-options: -Werror"        >> cabal.project
-    echo ""                              >> cabal.project
-    echo "keep-going:  False"            >> cabal.project
-    echo ""                              >> cabal.project
-    echo "package bytestring"            >> cabal.project
-    echo "  tests: False"                >> cabal.project
+    echo "allow-newer: HsYAML:base"                       >> cabal.project
+    echo ""                                               >> cabal.project
+    echo "package haskell-ci"                             >> cabal.project
+    echo "  ghc-options: -Werror -Werror=missing-methods" >> cabal.project
+    echo ""                                               >> cabal.project
+    echo "package cabal-install-parsers"                  >> cabal.project
+    echo "  ghc-options: -Werror -Werror=missing-methods" >> cabal.project
+    echo ""                                               >> cabal.project
+    echo "keep-going:  False"                             >> cabal.project
+    echo ""                                               >> cabal.project
+    echo "package bytestring"                             >> cabal.project
+    echo "  tests: False"                                 >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(Cabal|cabal-install-parsers|haskell-ci)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/fixtures/cabal.project.copy-fields.all.travis.yml
+++ b/fixtures/cabal.project.copy-fields.all.travis.yml
@@ -157,6 +157,18 @@ install:
     echo ""                                        >> cabal.project
     echo "package servant"                         >> cabal.project
     echo "  tests: False"                          >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant"                         >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-client"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-docs"                    >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-server"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -197,6 +209,18 @@ script:
     echo ""                                        >> cabal.project
     echo "package servant"                         >> cabal.project
     echo "  tests: False"                          >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant"                         >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-client"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-docs"                    >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-server"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/fixtures/cabal.project.copy-fields.none.travis.yml
+++ b/fixtures/cabal.project.copy-fields.none.travis.yml
@@ -151,6 +151,17 @@ install:
     echo "packages: servant-docs" >> cabal.project
     echo "packages: servant-server" >> cabal.project
   - |
+    echo "package servant"                        >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-client"                 >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-docs"                   >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-server"                 >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -185,6 +196,17 @@ script:
     echo "packages: ${PKGDIR_servant_docs}" >> cabal.project
     echo "packages: ${PKGDIR_servant_server}" >> cabal.project
   - |
+    echo "package servant"                        >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-client"                 >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-docs"                   >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-server"                 >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/fixtures/cabal.project.copy-fields.some.travis.yml
+++ b/fixtures/cabal.project.copy-fields.some.travis.yml
@@ -154,6 +154,18 @@ install:
     echo "constraints: foundation >= 0.14"         >> cabal.project
     echo "allow-newer: servant-js:servant"         >> cabal.project
     echo "allow-newer: servant-js:servant-foreign" >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant"                         >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-client"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-docs"                    >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-server"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -191,6 +203,18 @@ script:
     echo "constraints: foundation >= 0.14"         >> cabal.project
     echo "allow-newer: servant-js:servant"         >> cabal.project
     echo "allow-newer: servant-js:servant-foreign" >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant"                         >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-client"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-docs"                    >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-server"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/fixtures/cabal.project.empty-line.travis.yml
+++ b/fixtures/cabal.project.empty-line.travis.yml
@@ -171,6 +171,18 @@ install:
     echo "constraints: foundatiion >= 0.14"        >> cabal.project
     echo "allow-newer: servant-js:servant"         >> cabal.project
     echo "allow-newer: servant-js:servant-foreign" >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant"                         >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-client"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-docs"                    >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-server"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -208,6 +220,18 @@ script:
     echo "constraints: foundatiion >= 0.14"        >> cabal.project
     echo "allow-newer: servant-js:servant"         >> cabal.project
     echo "allow-newer: servant-js:servant-foreign" >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant"                         >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-client"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-docs"                    >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
+    echo ""                                        >> cabal.project
+    echo "package servant-server"                  >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods"  >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/fixtures/cabal.project.messy.travis.yml
+++ b/fixtures/cabal.project.messy.travis.yml
@@ -168,6 +168,17 @@ install:
     echo "packages: servant-docs" >> cabal.project
     echo "packages: servant-server" >> cabal.project
   - |
+    echo "package servant"                        >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-client"                 >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-docs"                   >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-server"                 >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
   - "for pkg in deepseq; do echo \"constraints: $pkg installed\" >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -202,6 +213,17 @@ script:
     echo "packages: ${PKGDIR_servant_docs}" >> cabal.project
     echo "packages: ${PKGDIR_servant_server}" >> cabal.project
   - |
+    echo "package servant"                        >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-client"                 >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-docs"                   >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
+    echo ""                                       >> cabal.project
+    echo "package servant-server"                 >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
   - "for pkg in deepseq; do echo \"constraints: $pkg installed\" >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/fixtures/cabal.project.travis-patch.travis.yml
+++ b/fixtures/cabal.project.travis-patch.travis.yml
@@ -148,6 +148,8 @@ install:
   - |
     echo "packages: servant" >> cabal.project
   - |
+    echo "package servant"                        >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -173,6 +175,8 @@ script:
   - |
     echo "packages: ${PKGDIR_servant}" >> cabal.project
   - |
+    echo "package servant"                        >> cabal.project
+    echo "  ghc-options: -Werror=missing-methods" >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.9.20200325
+version:            0.9.20200326
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.

--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -77,6 +77,7 @@ data Config = Config
     , cfgApt                 :: S.Set String
     , cfgTravisPatches       :: [FilePath]
     , cfgInsertVersion       :: !Bool
+    , cfgErrorMissingMethods :: !Bool
     , cfgDoctest             :: !DoctestConfig
     , cfgHLint               :: !HLintConfig
     , cfgConstraintSets      :: [ConstraintSet]
@@ -140,6 +141,7 @@ emptyConfig = Config
     , cfgTravisPatches   = []
     , cfgInsertVersion   = True
     , cfgRawProject      = []
+    , cfgErrorMissingMethods = True
     }
 
 -------------------------------------------------------------------------------
@@ -218,6 +220,8 @@ configGrammar = Config
         ^^^ metahelp "PATCH" ".patch files to apply to the generated Travis YAML file"
     <*> C.booleanFieldDef "insert-version"                                                    (field @"cfgInsertVersion") True
         ^^^ help "Don't insert the haskell-ci version into the generated Travis YAML file"
+    <*> C.booleanFieldDef "error-missing-methods"                                             (field @"cfgErrorMissingMethods") True
+        ^^^ help "Insert -Werror=missing-methods for local packages"
     <*> C.blurFieldGrammar (field @"cfgDoctest") doctestConfigGrammar
     <*> C.blurFieldGrammar (field @"cfgHLint")   hlintConfigGrammar
     <*> pure [] -- constraint sets

--- a/src/HaskellCI/Travis.hs
+++ b/src/HaskellCI/Travis.hs
@@ -597,9 +597,12 @@ makeTravis argv Config {..} prj JobVersions {..} = do
             CopyFieldsSome -> copyFieldsSome
             CopyFieldsAll  -> copyFieldsSome *> traverse_ item (prjOtherFields prj)
 
+        let localGhcOptions = cfgLocalGhcOptions
+                ++ [ "-Werror=missing-methods" | cfgErrorMissingMethods ]
+
         -- local ghc-options
-        unless (null cfgLocalGhcOptions) $ for_ pkgs $ \Pkg{pkgName} -> do
-            let s = unwords $ map (show . C.showToken) cfgLocalGhcOptions
+        unless (null localGhcOptions) $ for_ pkgs $ \Pkg{pkgName} -> do
+            let s = unwords $ map (show . C.showToken) localGhcOptions
             item $ C.PrettySection () "package" [PP.text pkgName] $ buildList $
                 item $ C.PrettyField () "ghc-options" $ PP.text s
 


### PR DESCRIPTION
Fixes https://github.com/haskell-CI/haskell-ci/issues/275

template-haskell-2.16 added liftTyped,
so now this good to add.