### PR TITLE
Require building with Cabal-3.2.* 

### DIFF
--- a/cabal-install-parsers/Changelog.md
+++ b/cabal-install-parsers/Changelog.md
@@ -1,11 +1,14 @@
 ## 0.3
 
+- Require `Cabal-3.2`.
 - Rename `prjOrigFields` to `prjOtherFields` to reflect its intended purpose:
   contain all fields of a `cabal.project` file that are not already covered by
   a different field of `Project`, such as `prjPackages`, `prjOptPackages`,
   `prjSourceRepos`, etc. The semantics of `parseProject` have also been changed
   accordingly, so `Project`s produced by `parseProject` will no longer have
   `prjOtherFields` entries that overlap with other `Project` fields.
+- `ParseError` from `Cabal.Parse` now parameterizes the list type used in
+  `peErrors`. Most of the time, this will be instantiated to `NonEmpty`.
 - Add `NFData` instances
 
 ## 0.2

--- a/cabal-install-parsers/cabal-install-parsers.cabal
+++ b/cabal-install-parsers/cabal-install-parsers.cabal
@@ -52,7 +52,7 @@ library
     , base          >=4.10     && <4.15
     , binary        ^>=0.8.5
     , bytestring    ^>=0.10.8.1
-    , Cabal         ^>=3.0.0.0 || ^>=3.2.0.0
+    , Cabal         ^>=3.2.0.0
     , containers    ^>=0.5.7.1 || ^>=0.6.0.1
     , deepseq       ^>=1.4.2.0
     , directory     ^>=1.3.0.0

--- a/cabal-install-parsers/src/Cabal/Config.hs
+++ b/cabal-install-parsers/src/Cabal/Config.hs
@@ -23,6 +23,7 @@ import Data.ByteString          (ByteString)
 import Data.Function            ((&))
 import Data.Functor.Identity    (Identity (..))
 import Data.List                (foldl')
+import Data.List.NonEmpty       (NonEmpty)
 import Data.Map                 (Map)
 import Data.Maybe               (fromMaybe)
 import Distribution.Compat.Lens (LensLike', over)
@@ -134,7 +135,7 @@ hackageHaskellOrg = "hackage.haskell.org"
 -------------------------------------------------------------------------------
 
 -- | Parse @~\/.cabal\/config@ file.
-parseConfig :: FilePath -> ByteString -> Either ParseError (Config Maybe)
+parseConfig :: FilePath -> ByteString -> Either (ParseError NonEmpty) (Config Maybe)
 parseConfig = parseWith $ \fields0 -> do
     let (fields1, sections) = C.partitionFields fields0
     let fields2 = M.filterWithKey (\k _ -> k `elem` knownFields) fields1

--- a/cabal-install-parsers/src/Cabal/Package.hs
+++ b/cabal-install-parsers/src/Cabal/Package.hs
@@ -5,6 +5,7 @@ module Cabal.Package (
 
 import Control.Exception            (throwIO)
 import Data.ByteString              (ByteString)
+import Data.List.NonEmpty           (NonEmpty)
 
 import qualified Data.ByteString                        as BS
 import qualified Distribution.Fields                    as C
@@ -23,7 +24,7 @@ readPackage fp = do
     either throwIO return (parsePackage fp contents)
 
 -- | Parse @.cabal@ file.
-parsePackage :: FilePath -> ByteString -> Either ParseError C.GenericPackageDescription
+parsePackage :: FilePath -> ByteString -> Either (ParseError NonEmpty) C.GenericPackageDescription
 parsePackage fp contents = case C.runParseResult $ C.parseGenericPackageDescription contents of
     (ws, Left (_mv, errs)) -> Left $ ParseError fp contents errs ws
     (_, Right gpd)         -> Right gpd

--- a/cabal-install-parsers/src/Cabal/Project.hs
+++ b/cabal-install-parsers/src/Cabal/Project.hs
@@ -35,6 +35,7 @@ import Data.Foldable                (toList)
 import Data.Function                ((&))
 import Data.Functor                 (void)
 import Data.List                    (foldl')
+import Data.List.NonEmpty           (NonEmpty)
 import Data.Traversable             (for)
 import Data.Void                    (Void)
 import Distribution.Compat.Lens     (LensLike', over)
@@ -160,7 +161,7 @@ readProject fp = do
 -- >>> fmap prjPackages $ parseProject "cabal.project" "packages: foo bar/*.cabal"
 -- Right ["foo","bar/*.cabal"]
 --
-parseProject :: FilePath -> ByteString -> Either ParseError (Project Void String String)
+parseProject :: FilePath -> ByteString -> Either (ParseError NonEmpty) (Project Void String String)
 parseProject = parseWith $ \fields0 -> do
     let (fields1, sections) = C.partitionFields fields0
     let fields2  = M.filterWithKey (\k _ -> k `elem` knownFields) fields1
@@ -312,7 +313,7 @@ resolveProject filePath prj = runExceptT $ do
 --
 -- May throw 'IOException'.
 --
-readPackagesOfProject :: Project uri opt FilePath -> IO (Either ParseError (Project uri opt (FilePath, C.GenericPackageDescription)))
+readPackagesOfProject :: Project uri opt FilePath -> IO (Either (ParseError NonEmpty) (Project uri opt (FilePath, C.GenericPackageDescription)))
 readPackagesOfProject prj = runExceptT $ for prj $ \fp -> do
     contents <- liftIO $ BS.readFile fp
     either throwE (\gpd -> return (fp, gpd)) (parsePackage fp contents)

--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,3 @@ tests: True
 package haskell-ci
   ghc-options: -Wall
   ghc-options: -Werror
-
--- GHC-8.10
------------
-allow-newer: HsYAML:base

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -137,7 +137,7 @@ library haskell-ci-internal
   build-depends:
     , base          >=4.10     && <4.15
     , bytestring    ^>=0.10.8.1
-    , Cabal         ^>=3.0
+    , Cabal         ^>= 3.2
     , containers    ^>=0.5.7.1 || ^>=0.6.0.1
     , deepseq       ^>=1.4.2.0
     , directory     ^>=1.3.0.0

--- a/src/HaskellCI/Config/Dump.hs
+++ b/src/HaskellCI/Config/Dump.hs
@@ -53,6 +53,11 @@ instance C.FieldGrammar DumpGrammar where
         , ""
         ]
 
+    freeTextFieldDefST fn _ = DG
+        [ fromUTF8BS fn ++ ":"
+        , ""
+        ]
+
     prefixedFields _ _   = pure []
     knownField _         = pure ()
     deprecatedSince _  _ = id

--- a/src/HaskellCI/OptparseGrammar.hs
+++ b/src/HaskellCI/OptparseGrammar.hs
@@ -80,6 +80,9 @@ instance C.FieldGrammar OptparseGrammar where
     freeTextFieldDef fn l = OG
         [ SP $ \m h -> setOG l $ O.strOption $ optionMods fn m h ]
 
+    freeTextFieldDefST fn l = OG
+        [ SP $ \m h -> setOG l $ O.strOption $ optionMods fn m h ]
+
 instance OptionsGrammar OptparseGrammar where
     help h (OG ps) = OG
         [ SP $ \m _h -> p m (Just h)

--- a/src/HaskellCI/ParsecUtils.hs
+++ b/src/HaskellCI/ParsecUtils.hs
@@ -38,5 +38,5 @@ readAndParseFile parser fpath = do
             hPutStr stderr $ renderParseError (ParseError fpath bs [] ws)
             return x
         (ws, Left (_, es)) -> do
-            hPutStr stderr $ renderParseError (ParseError fpath bs es ws)
+            hPutStr stderr $ renderParseError (ParseError fpath bs (toList es) ws)
             exitFailure


### PR DESCRIPTION
As far as I can tell, there are only two changes in `Cabal-3.2.*`                              
that matter to `cabal-install-parsers`/`haskell-ci`:                                           
                                                                                               
* The type of `runParseResult` has changed:                                                    
                                                                                               
  ```diff                                                                                      
  -runParseResult :: ParseResult a -> ([PWarning], Either (Maybe Version, [PError])        a)  
  +runParseResult :: ParseResult a -> ([PWarning], Either (Maybe Version, NonEmpty PError) a)  
  ```                                                                                          

  Currently, various code paths invoke `runParseResult` and store the returned `[PError]` in the `peErrors` field of `ParseError`. To accommodate the new type signature of `runParseResult`, I have changed `ParseError` to be parameterized over the list type for `peErrors`. Most of the time, this will be instantiated to `NonEmpty`, although there is one place in `HaskellCI.ParseUtils` where this is instantiated to `[]`.
* The `FieldGrammar` class has a new method:

  ```hs
  class FieldGrammar g where
      ...
      -- | @since 3.2.0.0
      freeTextFieldDefST
          :: FieldName
          -> ALens' s ShortText -- ^ lens into the field
          -> g s ShortText
      ...
  ```

  Implementing this proves straightforward.