### PR TITLE
Expand default hlint-version to include 3.0

### DIFF
--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -64,7 +64,7 @@ folds: constraint-sets
 hlint: False
 hlint-yaml: .hlint.yaml
 hlint-download-binary: True
--- hlint-version: ==2.2.*
+-- hlint-version: ==2.2.* || ==3.0.*
 
 -- Run doctest (on GHC-8.0+ which support .ghc.environment)
 doctest: True

--- a/src/HaskellCI/Config/HLint.hs
+++ b/src/HaskellCI/Config/HLint.hs
@@ -27,7 +27,7 @@ data HLintConfig = HLintConfig
   deriving (Show, Generic)
 
 defaultHLintVersion :: VersionRange
-defaultHLintVersion = withinVersion (mkVersion [2,2])
+defaultHLintVersion = withinVersion (mkVersion [2,2]) \/ withinVersion (mkVersion [3,0])
 
 -------------------------------------------------------------------------------
 -- HLintJob


### PR DESCRIPTION
Now that hlint-3.0 is out, it seems like an appropriate time to widen the upper version bounds in the default `hlint-version`.