### PR TITLE
Correct name of install-dependencies option in cabal.haskell-ci

### DIFF
--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -34,7 +34,7 @@ haddock: True
 
 -- Install dependencies in a separate step
 -- If your project has inplace packages, you want to disable this.
--- install-dependencies-step: True
+-- install-dependencies: True
 
 -- --no-tests --no-benchmarks build is useful to verify that package
 -- builds when less constrained


### PR DESCRIPTION
It was referred to as `install-dependencies-step`, not `install-dependencies` (the actual name), in the comments.