### PR TITLE
GitHub Actions: Use sensible `on` default when --branches isn't set

### DIFF
--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.11.20201214
+version:            0.11.20201215
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.

--- a/src/HaskellCI/GitHub/Yaml.hs
+++ b/src/HaskellCI/GitHub/Yaml.hs
@@ -70,10 +70,14 @@ instance ToYaml GitHub where
         ]
 
 instance ToYaml GitHubOn where
-    toYaml GitHubOn {..} = ykeyValuesFilt []
-        [ "push"         ~> branches
-        , "pull_request" ~> branches
-        ]
+    toYaml GitHubOn {..}
+        | null ghBranches
+        = ylistFilt [] ["push", "pull_request"]
+        | otherwise
+        = ykeyValuesFilt []
+              [ "push"         ~> branches
+              , "pull_request" ~> branches
+              ]
       where
         branches = ykeyValuesFilt []
             [ "branches" ~> ylistFilt [] (map fromString ghBranches)


### PR DESCRIPTION
Fixes #419.