### PR TITLE
Consistently use parallelism when building dependencies

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -164,8 +164,8 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
       - name: install dependencies
         run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only all
-          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only all
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only -j2 all
       - name: build w/o tests
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all

--- a/haskell-ci.sh
+++ b/haskell-ci.sh
@@ -447,7 +447,7 @@ run_cmd cabal-plan --version
 # install doctest
 put_info "install doctest"
 # install doctest
-run_cmd $CABAL v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.17'
+run_cmd $CABAL v2-install $ARG_COMPILER --ignore-project -j doctest --constraint='doctest ^>=0.17'
 run_cmd doctest --version
 
 # sdist
@@ -497,8 +497,8 @@ run_cmd cabal-plan
 
 # install dependencies
 put_info "install dependencies"
-run_cmd $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only all
-run_cmd $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only all
+run_cmd $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j all
+run_cmd $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only -j all
 
 # build w/o tests
 put_info "build w/o tests"

--- a/src/HaskellCI/Bash.hs
+++ b/src/HaskellCI/Bash.hs
@@ -29,6 +29,13 @@ import HaskellCI.Sh
 import HaskellCI.ShVersionRange
 import HaskellCI.Tools
 
+{-
+Bash-specific notes:
+
+* We use -j for parallelism, as the exact number of cores depends on the
+  particular machine the script is being run on.
+-}
+
 makeBash
     :: [String]
     -> Config
@@ -41,7 +48,7 @@ makeBash _argv config@Config {..} prj jobs@JobVersions {..} = do
         when doctestEnabled $ step "install doctest" $ do
             let range = (Range (cfgDoctestEnabled cfgDoctest) /\ doctestJobVersionRange)
             comment "install doctest"
-            run_cmd_if range "$CABAL v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.17'"
+            run_cmd_if range "$CABAL v2-install $ARG_COMPILER --ignore-project -j doctest --constraint='doctest ^>=0.17'"
             run_cmd_if range "doctest --version"
 
         -- install hlint
@@ -126,8 +133,8 @@ makeBash _argv config@Config {..} prj jobs@JobVersions {..} = do
 
         -- install dependencies
         when cfgInstallDeps $ step "install dependencies" $ do
-            run_cmd "$CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only all"
-            run_cmd "$CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only all"
+            run_cmd "$CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j all"
+            run_cmd "$CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only -j all"
 
         unless (equivVersionRanges C.noVersion cfgNoTestsNoBench) $ step "build w/o tests" $ do
             run_cmd "$CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all"

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -65,6 +65,13 @@ githubHeader insertVersion argv =
 -- GitHub
 -------------------------------------------------------------------------------
 
+{-
+GitHub Actions–specific notes:
+
+* We use -j2 for parallelism, as GitHub's virtual machines use 2 cores, per
+  https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources.
+-}
+
 makeGitHub
     :: [String]
     -> Config
@@ -253,8 +260,8 @@ makeGitHub _argv config@Config {..} prj jobs@JobVersions {..} = do
 
         -- install dependencies
         when cfgInstallDeps $ githubRun "install dependencies" $ do
-            sh "$CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only all"
-            sh "$CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only all"
+            sh "$CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all"
+            sh "$CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only -j2 all"
 
         -- build w/o tests benchs
         unless (equivVersionRanges C.noVersion cfgNoTestsNoBench) $ githubRun "build w/o tests" $ do

--- a/src/HaskellCI/Travis.hs
+++ b/src/HaskellCI/Travis.hs
@@ -65,6 +65,13 @@ travisHeader insertVersion argv =
 -- Generate travis configuration
 -------------------------------------------------------------------------------
 
+{-
+Travis CI–specific notes:
+
+* We use -j2 for parallelism, as Travis' virtual environments use 2 cores, per
+  https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system.
+-}
+
 makeTravis
     :: [String]
     -> Config
@@ -241,11 +248,11 @@ makeTravis argv config@Config {..} prj jobs@JobVersions {..} = do
 
         -- Install cabal-plan (for ghcjs tests)
         when (anyGHCJS && cfgGhcjsTests) $ do
-            shForJob RangeGHCJS $ cabal "v2-install -w ghc-8.4.4 --ignore-project cabal-plan --constraint='cabal-plan ^>=0.6.0.0' --constraint='cabal-plan +exe'"
+            shForJob RangeGHCJS $ cabal "v2-install -w ghc-8.4.4 --ignore-project -j2 cabal-plan --constraint='cabal-plan ^>=0.6.0.0' --constraint='cabal-plan +exe'"
 
         -- Install happy
         when anyGHCJS $ for_ cfgGhcjsTools $ \t ->
-            shForJob RangeGHCJS $ cabal $ "v2-install -w ghc-8.4.4 --ignore-project " ++ C.prettyShow t
+            shForJob RangeGHCJS $ cabal $ "v2-install -w ghc-8.4.4 --ignore-project -j2" ++ C.prettyShow t
 
         -- create cabal.project file
         generateCabalProject False


### PR DESCRIPTION
I also added comments to each backend's module that explains why the particular choice of `-j` is used for that module.

Fixes #421.