### PR TITLE
GitHub Actions: support --allow-failures through continue-on-error

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -24,8 +24,11 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
+    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
       matrix:
+        continue-on-error:
+          - false
         include:
           - ghc: 8.10.1
           - ghc: 8.8.3

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -20,7 +20,7 @@ on:
       - master
 jobs:
   linux:
-    name: Haskell-CI Linux
+    name: Haskell-CI Linux - GHC ${{ matrix.ghc }}
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.11.20201215
+version:            0.11.20201216
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -353,12 +353,13 @@ makeGitHub _argv config@Config {..} prj jobs@JobVersions {..} = do
             , ghjSteps     = steps
             , ghjContainer = Just "buildpack-deps:bionic" -- use cfgUbuntu?
             , ghjMatrix    =
-                [ Map.fromList
-                    [ ("ghc", v')
-                    -- , ("isGhcjs", "0")
-                    ]
-                | GHC v <- reverse $ toList versions
-                , let v' = prettyShow v
+                [ GitHubMatrixEntry
+                    { ghmeGhcVersion = v
+                    , ghmeContinueOnError =
+                           previewGHC cfgHeadHackage compiler
+                        || maybeGHC False (`C.withinRange` cfgAllowFailures) compiler
+                    }
+                | compiler@(GHC v) <- reverse $ toList versions
                 ]
             }
         }

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -348,7 +348,7 @@ makeGitHub _argv config@Config {..} prj jobs@JobVersions {..} = do
             { ghBranches = cfgOnlyBranches
             }
         , ghJobs = Map.singleton "linux" GitHubJob
-            { ghjName      = "Haskell-CI Linux"
+            { ghjName      = "Haskell-CI Linux - GHC ${{ matrix.ghc }}"
             , ghjRunsOn    = "ubuntu-18.04" -- TODO: use cfgUbuntu
             , ghjSteps     = steps
             , ghjContainer = Just "buildpack-deps:bionic" -- use cfgUbuntu?


### PR DESCRIPTION
The UX for `continue-on-error` is not the greatest, but it's the closest thing we have to `allow-failures` in GitHub Actions.

Fixes #424.