### PR TITLE
GitHub Actions: Allowed failure cleanup

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -24,17 +24,20 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
-    continue-on-error: ${{ matrix.continue-on-error }}
+    continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
-        continue-on-error:
-          - false
         include:
           - ghc: 8.10.1
+            allow-failure: false
           - ghc: 8.8.3
+            allow-failure: false
           - ghc: 8.6.5
+            allow-failure: false
           - ghc: 8.4.4
+            allow-failure: false
           - ghc: 8.2.2
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -355,7 +355,7 @@ makeGitHub _argv config@Config {..} prj jobs@JobVersions {..} = do
             , ghjMatrix    =
                 [ GitHubMatrixEntry
                     { ghmeGhcVersion = v
-                    , ghmeContinueOnError =
+                    , ghmeAllowFailure =
                            previewGHC cfgHeadHackage compiler
                         || maybeGHC False (`C.withinRange` cfgAllowFailures) compiler
                     }

--- a/src/HaskellCI/GitHub/Yaml.hs
+++ b/src/HaskellCI/GitHub/Yaml.hs
@@ -36,8 +36,8 @@ data GitHubJob = GitHubJob
   deriving (Show)
 
 data GitHubMatrixEntry = GitHubMatrixEntry
-    { ghmeGhcVersion      :: Version
-    , ghmeContinueOnError :: Bool
+    { ghmeGhcVersion   :: Version
+    , ghmeAllowFailure :: Bool
     }
   deriving (Show)
 
@@ -95,11 +95,10 @@ instance ToYaml GitHubJob where
         , "runs-on" ~> fromString ghjRunsOn
         , "container" ~> ykeyValuesFilt [] (buildList $
             for_ ghjContainer $ \image -> item $ "image" ~> fromString image)
-        , "continue-on-error" ~> fromString "${{ matrix.continue-on-error }}"
+        , "continue-on-error" ~> fromString "${{ matrix.allow-failure }}"
         , "strategy" ~> ykeyValuesFilt []
             [ "matrix" ~> ykeyValuesFilt []
-                [ "continue-on-error" ~> toYaml [False]
-                , "include" ~> ylistFilt [] (map toYaml ghjMatrix)
+                [ "include" ~> ylistFilt [] (map toYaml ghjMatrix)
                 ]
             , "fail-fast" ~> YBool [] False
             ]
@@ -107,10 +106,10 @@ instance ToYaml GitHubJob where
         ]
 
 instance ToYaml GitHubMatrixEntry where
-    toYaml GitHubMatrixEntry {..} = ykeyValuesFilt [] $ buildList $ do
-        item $ "ghc" ~> fromString (prettyShow ghmeGhcVersion)
-        when ghmeContinueOnError $
-          item $ "continue-on-error" ~> toYaml True
+    toYaml GitHubMatrixEntry {..} = ykeyValuesFilt []
+        [ "ghc" ~> fromString (prettyShow ghmeGhcVersion)
+        , "allow-failure" ~> toYaml ghmeAllowFailure
+        ]
 
 instance ToYaml GitHubStep where
     toYaml GitHubStep {..} = ykeyValuesFilt [] $


### PR DESCRIPTION
Unfortunately, omitting a property like `continue-on-error` from all `include` entry causes only one job to be run, as observed in https://github.com/haskell-CI/haskell-ci/pull/425#issuecomment-747047769. To work around this, we now enumerate `continue-on-error` in each `include` entry, verbose as it may be.

While I was in town, I renamed the property in each `include` entry from `continue-on-error` to `allow-failure`, as this makes it less likely to confuse with the top-level `continue-on-error` property (a separate thing entirely).