### PR TITLE
GitHub Actions: Install extra packages from --apt

### DIFF
--- a/fixtures/messy.github
+++ b/fixtures/messy.github
@@ -86,7 +86,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2
+          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2 fftw3-dev
         env:
           GHC_VERSION: ${{ matrix.ghc }}
       - name: Set PATH and environment variables

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.11.20201217
+version:            0.11.20201219
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -94,7 +94,8 @@ makeGitHub _argv config@Config {..} prj jobs@JobVersions {..} = do
             sh "apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common"
             sh "apt-add-repository -y 'ppa:hvr/ghc'"
             sh "apt-get update"
-            sh "apt-get install -y ghc-$GHC_VERSION cabal-install-3.2" -- TODO: cabal version
+            sh $ unwords $ "apt-get install -y ghc-$GHC_VERSION cabal-install-3.2" -- TODO: cabal version
+                         : S.toList cfgApt
 
         githubRun' "Set PATH and environment variables" envEnv $ do
             echo_to "$GITHUB_PATH" "$HOME/.cabal/bin"


### PR DESCRIPTION
The Travis and Bash backends already do this, but the GitHub Actions backend did not due to a small oversight.