### PR TITLE
UX: Improve discoverability of --jobs-selection any

### DIFF
--- a/fixtures/fail-versions.bash
+++ b/fixtures/fail-versions.bash
@@ -1,3 +1,4 @@
 # FAILURE
+# *INFO* Consider option --jobs-selection any
 # *ERROR* servant-client-core is missing tested-with annotations for: ghc-7.8.1,ghc-7.8.2,ghc-7.8.3,ghc-7.8.4
 # *ERROR* servant-foreign is missing tested-with annotations for: ghc-7.8.1,ghc-7.8.2,ghc-7.8.3,ghc-7.8.4

--- a/fixtures/fail-versions.github
+++ b/fixtures/fail-versions.github
@@ -1,3 +1,4 @@
 # FAILURE
+# *INFO* Consider option --jobs-selection any
 # *ERROR* servant-client-core is missing tested-with annotations for: ghc-7.8.1,ghc-7.8.2,ghc-7.8.3,ghc-7.8.4
 # *ERROR* servant-foreign is missing tested-with annotations for: ghc-7.8.1,ghc-7.8.2,ghc-7.8.3,ghc-7.8.4

--- a/fixtures/fail-versions.travis
+++ b/fixtures/fail-versions.travis
@@ -1,3 +1,4 @@
 # FAILURE
+# *INFO* Consider option --jobs-selection any
 # *ERROR* servant-client-core is missing tested-with annotations for: ghc-7.8.1,ghc-7.8.2,ghc-7.8.3,ghc-7.8.4
 # *ERROR* servant-foreign is missing tested-with annotations for: ghc-7.8.1,ghc-7.8.2,ghc-7.8.3,ghc-7.8.4


### PR DESCRIPTION
This PR adds hint
```
  (Consider option --jobs-selection any)
```
to
```
  *ERROR* FOO is missing tested-with annotation for: ghc-x.y.z
```
To deal with linebreaks in errors in the golden testsuite, I had to make the `cmp` function more robust.  Now it first normalizes the comparatees wrt. line breaks via the normalization function
```
  unlines . lines
```
See e.g. https://github.com/haskell-CI/haskell-ci/issues/385#issuecomment-619156827 why this UX improvement is helpful.