### PR TITLE
GHA backend: Add head.hackage support

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -89,6 +89,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          if [ $((HCNUMVER > 81002)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> $GITHUB_ENV ; else echo "HEADHACKAGE=false" >> $GITHUB_ENV ; fi
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
@@ -115,6 +116,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABAL_CONFIG
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |

--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -128,6 +128,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:

--- a/fixtures/copy-fields-all.github
+++ b/fixtures/copy-fields-all.github
@@ -106,6 +106,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:

--- a/fixtures/copy-fields-none.github
+++ b/fixtures/copy-fields-none.github
@@ -106,6 +106,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:

--- a/fixtures/copy-fields-some.github
+++ b/fixtures/copy-fields-some.github
@@ -106,6 +106,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:

--- a/fixtures/empty-line.github
+++ b/fixtures/empty-line.github
@@ -106,6 +106,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          if [ $((HCNUMVER > 81003)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> $GITHUB_ENV ; else echo "HEADHACKAGE=false" >> $GITHUB_ENV ; fi
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
@@ -132,6 +133,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABAL_CONFIG
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |

--- a/fixtures/irc-channels.github
+++ b/fixtures/irc-channels.github
@@ -131,6 +131,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:

--- a/fixtures/messy.github
+++ b/fixtures/messy.github
@@ -106,6 +106,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          if [ $((HCNUMVER > 81003)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> $GITHUB_ENV ; else echo "HEADHACKAGE=false" >> $GITHUB_ENV ; fi
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
@@ -132,6 +133,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABAL_CONFIG
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |

--- a/fixtures/psql.github
+++ b/fixtures/psql.github
@@ -112,6 +112,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:

--- a/fixtures/travis-patch.github
+++ b/fixtures/travis-patch.github
@@ -106,6 +106,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
           echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -41,12 +41,12 @@ extra-source-files:
   fixtures/*.patch
   fixtures/*.project
   fixtures/*.travis
-  fixtures/servant-client/servant-client.cabal
-  fixtures/servant-foreign/servant-foreign.cabal
-  fixtures/servant-client-core/servant-client-core.cabal
-  fixtures/servant-server/servant-server.cabal
   fixtures/servant/servant.cabal
+  fixtures/servant-client/servant-client.cabal
+  fixtures/servant-client-core/servant-client-core.cabal
   fixtures/servant-docs/servant-docs.cabal
+  fixtures/servant-foreign/servant-foreign.cabal
+  fixtures/servant-server/servant-server.cabal
   fixtures/splitmix/splitmix.cabal
 
 source-repository head
@@ -90,6 +90,7 @@ library haskell-ci-internal
     HaskellCI.GitConfig
     HaskellCI.GitHub
     HaskellCI.GitHub.Yaml
+    HaskellCI.HeadHackage
     HaskellCI.Jobs
     HaskellCI.List
     HaskellCI.MonadErr

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -36,6 +36,7 @@ import HaskellCI.Config.Installed
 import HaskellCI.Config.PackageScope
 import HaskellCI.GitConfig
 import HaskellCI.GitHub.Yaml
+import HaskellCI.HeadHackage
 import HaskellCI.Jobs
 import HaskellCI.List
 import HaskellCI.Package
@@ -133,6 +134,9 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
             if_then_else (Range cfgBenchmarks)
                 (tell_env' "ARG_BENCH" "--enable-benchmarks")
                 (tell_env' "ARG_BENCH" "--disable-benchmarks")
+            if_then_else (Range cfgHeadHackage \/ RangePoints (S.singleton GHCHead))
+                (tell_env' "HEADHACKAGE" "true")
+                (tell_env' "HEADHACKAGE" "false")
 
             tell_env "ARG_COMPILER" ("--ghc --with-compiler=" ++ hc)
 
@@ -159,9 +163,17 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
                 , "repository hackage.haskell.org"
                 , "  url: http://hackage.haskell.org/"
                 ]
-            sh "cat $CABAL_CONFIG"
 
-            -- TODO: head.hackage
+            -- Add head.hackage repository to ~/.cabal/config
+            -- (locally you want to add it to cabal.project)
+            unless (S.null headGhcVers) $ sh $ concat $
+                [ "if $HEADHACKAGE; then\n"
+                , "echo \"allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\\1/g')\" >> $CABAL_CONFIG\n"
+                , catCmd "$CABAL_CONFIG" $ unlines headHackageRepoStanza
+                , "\nfi"
+                ]
+
+            sh "cat $CABAL_CONFIG"
 
         githubRun "versions" $ do
             sh "$HC --version || true"
@@ -460,6 +472,10 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
 
     Auxiliary {..} = auxiliary config prj jobs
 
+    -- GHC versions which need head.hackage
+    headGhcVers :: Set CompilerVersion
+    headGhcVers = S.filter (previewGHC cfgHeadHackage) versions
+
     -- step primitives
     githubRun' :: String -> Map.Map String String ->  ShM () -> ListBuilder (Either ShError GitHubStep) ()
     githubRun' name env shm = item $ do
@@ -595,12 +611,15 @@ ircJob actionName mainJobName projectName cfg gitconfig = item ("irc", GitHubJob
                                     ++ "The build " ++ resultPastTense ++ ".")
             ]
 
-cat :: FilePath -> String -> ShM ()
-cat path contents = sh $ concat
+catCmd :: FilePath -> String -> String
+catCmd path contents = concat
     [ "cat >> " ++ path ++ " <<EOF\n"
     , contents
     , "EOF"
     ]
+
+cat :: FilePath -> String -> ShM ()
+cat path contents = sh $ catCmd path contents
 
 -- | GitHub is very lenient and undocumented. We accept something.
 -- Please, write a patch, if you need an extra scheme to be accepted.

--- a/src/HaskellCI/HeadHackage.hs
+++ b/src/HaskellCI/HeadHackage.hs
@@ -1,0 +1,14 @@
+module HaskellCI.HeadHackage where
+
+import HaskellCI.Prelude
+
+headHackageRepoStanza :: [String]
+headHackageRepoStanza =
+    [ "repository head.hackage.ghc.haskell.org"
+    , "   url: https://ghc.gitlab.haskell.org/head.hackage/"
+    , "   secure: True"
+    , "   root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d"
+    , "              26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329"
+    , "              f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89"
+    , "   key-threshold: 3"
+    ]

--- a/src/HaskellCI/Travis.hs
+++ b/src/HaskellCI/Travis.hs
@@ -29,6 +29,7 @@ import HaskellCI.Config.HLint
 import HaskellCI.Config.Installed
 import HaskellCI.Config.Jobs
 import HaskellCI.Config.PackageScope
+import HaskellCI.HeadHackage
 import HaskellCI.Jobs
 import HaskellCI.List
 import HaskellCI.MonadErr
@@ -174,15 +175,7 @@ makeTravis argv config@Config {..} prj jobs@JobVersions {..} = do
             [ "if $HEADHACKAGE; then"
             , "echo \"allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\\1/g')\" >> $CABALHOME/config"
             ] ++
-            lines (catCmd Double "$CABALHOME/config"
-            [ "repository head.hackage.ghc.haskell.org"
-            , "   url: https://ghc.gitlab.haskell.org/head.hackage/"
-            , "   secure: True"
-            , "   root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d"
-            , "              26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329"
-            , "              f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89"
-            , "   key-threshold: 3"
-            ]) ++
+            lines (catCmd Double "$CABALHOME/config" headHackageRepoStanza) ++
             [ "fi"
             ]
 


### PR DESCRIPTION
This makes the GitHub Actions backend respect the `--head-hackage` flag, much
in the same way that the Travis backend does.

Altered by Oleg Grenrus: added HeadHackage module with shared stanza

---

Rebased and amended #473 