### PR TITLE
Work around haskell/cabal#7291 by writing allow-newer to cabal.project, not ~/.cabal/config

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -119,7 +119,6 @@ jobs:
             url: http://hackage.haskell.org/
           EOF
           if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABAL_CONFIG
           cat >> $CABAL_CONFIG <<EOF
           repository head.hackage.ghc.haskell.org
              url: https://ghc.gitlab.haskell.org/head.hackage/
@@ -223,6 +222,9 @@ jobs:
           package bytestring
             tests: False
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(Cabal|cabal-install-parsers|haskell-ci)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/fixtures/empty-line.github
+++ b/fixtures/empty-line.github
@@ -136,7 +136,6 @@ jobs:
             url: http://hackage.haskell.org/
           EOF
           if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABAL_CONFIG
           cat >> $CABAL_CONFIG <<EOF
           repository head.hackage.ghc.haskell.org
              url: https://ghc.gitlab.haskell.org/head.hackage/
@@ -214,6 +213,9 @@ jobs:
           allow-newer: servant-js:servant
           allow-newer: servant-js:servant-foreign
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(servant|servant-client|servant-docs|servant-server)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/fixtures/empty-line.travis
+++ b/fixtures/empty-line.travis
@@ -159,7 +159,6 @@ before_install:
     echo "  url: http://hackage.haskell.org/"           >> $CABALHOME/config
   - |
     if $HEADHACKAGE; then
-    echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABALHOME/config
     echo "repository head.hackage.ghc.haskell.org"                                        >> $CABALHOME/config
     echo "   url: https://ghc.gitlab.haskell.org/head.hackage/"                           >> $CABALHOME/config
     echo "   secure: True"                                                                >> $CABALHOME/config
@@ -197,6 +196,10 @@ install:
     echo "constraints: foundatiion >= 0.14"        >> cabal.project
     echo "allow-newer: servant-js:servant"         >> cabal.project
     echo "allow-newer: servant-js:servant-foreign" >> cabal.project
+  - |
+    if $HEADHACKAGE; then
+    echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> $CABALHOME/config
+    fi
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -242,6 +245,10 @@ script:
     echo "constraints: foundatiion >= 0.14"        >> cabal.project
     echo "allow-newer: servant-js:servant"         >> cabal.project
     echo "allow-newer: servant-js:servant-foreign" >> cabal.project
+  - |
+    if $HEADHACKAGE; then
+    echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> $CABALHOME/config
+    fi
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(servant|servant-client|servant-docs|servant-server)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/fixtures/messy.github
+++ b/fixtures/messy.github
@@ -136,7 +136,6 @@ jobs:
             url: http://hackage.haskell.org/
           EOF
           if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABAL_CONFIG
           cat >> $CABAL_CONFIG <<EOF
           repository head.hackage.ghc.haskell.org
              url: https://ghc.gitlab.haskell.org/head.hackage/
@@ -211,6 +210,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           cat >> cabal.project.local <<EOF
           constraints: deepseq installed
           EOF

--- a/fixtures/messy.travis
+++ b/fixtures/messy.travis
@@ -159,7 +159,6 @@ before_install:
     echo "  url: http://hackage.haskell.org/"           >> $CABALHOME/config
   - |
     if $HEADHACKAGE; then
-    echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABALHOME/config
     echo "repository head.hackage.ghc.haskell.org"                                        >> $CABALHOME/config
     echo "   url: https://ghc.gitlab.haskell.org/head.hackage/"                           >> $CABALHOME/config
     echo "   secure: True"                                                                >> $CABALHOME/config
@@ -194,6 +193,10 @@ install:
   - if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo 'package servant-server' >> cabal.project ; fi
   - "if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
   - |
+  - |
+    if $HEADHACKAGE; then
+    echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> $CABALHOME/config
+    fi
   - "for pkg in deepseq; do echo \"constraints: $pkg installed\" >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -236,6 +239,10 @@ script:
   - if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo 'package servant-server' >> cabal.project ; fi
   - "if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
   - |
+  - |
+    if $HEADHACKAGE; then
+    echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> $CABALHOME/config
+    fi
   - "for pkg in deepseq; do echo \"constraints: $pkg installed\" >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.11.20210220
+version:            0.11.20210221
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for [Travis-CI](https://travis-ci.org/) for continuous-integration testing of Haskell Cabal packages.


### PR DESCRIPTION
Due to haskell/cabal#7291, attempting to use `haskell-ci` with `head.hackage` currently will result in `cabal v2-update` hanging forever. I have worked around the issue by writing the `allow-newer` information to `cabal.project` rather than `~/.cabal/config`.