### PR TITLE
[ Fix #487 ] enable bash-completion for file and directories

### DIFF
--- a/src/HaskellCI/Cli.hs
+++ b/src/HaskellCI/Cli.hs
@@ -95,19 +95,19 @@ optionsP :: O.Parser Options
 optionsP = Options
     <$> O.optional outputP
     <*> configOptP
-    <*> O.optional (O.strOption (O.long "cwd" <> O.metavar "Dir" <> O.help "Directory to change to"))
+    <*> O.optional (O.strOption (O.long "cwd" <> O.metavar "Dir" <> O.action "directory" <> O.help "Directory to change to"))
     <*> O.optional inputTypeP
     <*> runOptparseGrammar configGrammar
 
 configOptP :: O.Parser ConfigOpt
 configOptP = file <|> noconfig <|> pure ConfigOptAuto
   where
-    file = ConfigOpt <$> O.strOption (O.long "config" <> O.metavar "CONFIGFILE" <> O.help "Configuration file")
+    file = ConfigOpt <$> O.strOption (O.long "config" <> O.metavar "CONFIGFILE" <> O.action "file" <> O.help "Configuration file")
     noconfig = O.flag' ConfigOptNo (O.long "no-config" <> O.help "Don't read configuration file")
 
 outputP :: O.Parser Output
 outputP =
-    OutputFile <$> O.strOption (O.long "output" <> O.short 'o' <> O.metavar "FILE" <> O.help "Output file") <|>
+    OutputFile <$> O.strOption (O.long "output" <> O.short 'o' <> O.metavar "FILE" <> O.action "file" <> O.help "Output file") <|>
     O.flag' OutputStdout (O.long "stdout" <> O.help "Use stdout output")
 
 versionP :: O.Parser (a -> a)
@@ -139,13 +139,13 @@ cliParserInfo = O.info ((,) <$> cmdP <*> optionsP O.<**> versionP O.<**> O.helpe
         ]) <|> travisP
 
     travisP = CommandTravis
-        <$> O.strArgument (O.metavar "CABAL.FILE" <> O.help "Either <pkg.cabal> or cabal.project")
+        <$> O.strArgument (O.metavar "CABAL.FILE" <> O.action "file" <> O.help "Either <pkg.cabal> or cabal.project")
 
     bashP = CommandBash
-        <$> O.strArgument (O.metavar "CABAL.FILE" <> O.help "Either <pkg.cabal> or cabal.project")
+        <$> O.strArgument (O.metavar "CABAL.FILE" <> O.action "file" <> O.help "Either <pkg.cabal> or cabal.project")
 
     githubP = CommandGitHub
-        <$> O.strArgument (O.metavar "CABAL.FILE" <> O.help "Either <pkg.cabal> or cabal.project")
+        <$> O.strArgument (O.metavar "CABAL.FILE" <> O.action "file" <> O.help "Either <pkg.cabal> or cabal.project")
 
 -------------------------------------------------------------------------------
 -- Parsing helpers

--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -237,9 +237,9 @@ configGrammar = Config
     <*> C.monoidalFieldAla    "apt"                       (alaSet' C.NoCommaFSep C.Token')    (field @"cfgApt")
         ^^^ metahelp "PKG" "Additional apt packages to install"
     <*> C.monoidalFieldAla    "travis-patches"            (C.alaList' C.NoCommaFSep C.Token') (field @"cfgTravisPatches")
-        ^^^ metahelp "PATCH" ".patch files to apply to the generated Travis YAML file"
+        ^^^ metaActionHelp "PATCH" "file" ".patch files to apply to the generated Travis YAML file"
     <*> C.monoidalFieldAla    "github-patches"            (C.alaList' C.NoCommaFSep C.Token') (field @"cfgGitHubPatches")
-        ^^^ metahelp "PATCH" ".patch files to apply to the generated GitHub Actions YAML file"
+        ^^^ metaActionHelp "PATCH" "file" ".patch files to apply to the generated GitHub Actions YAML file"
     <*> C.booleanFieldDef "insert-version"                                                    (field @"cfgInsertVersion") True
         ^^^ help "Don't insert the haskell-ci version into the generated Travis YAML file"
     <*> C.optionalFieldDef "error-missing-methods"                                            (field @"cfgErrorMissingMethods") PackageScopeLocal

--- a/src/HaskellCI/Config/HLint.hs
+++ b/src/HaskellCI/Config/HLint.hs
@@ -73,7 +73,7 @@ hlintConfigGrammar = HLintConfig
     <*> C.optionalFieldDef "hlint-job"                                         (field @"cfgHLintJob") HLintJobLatest
         ^^^ metahelp "JOB" "Specify HLint job"
     <*> C.optionalFieldAla "hlint-yaml"    C.FilePathNT                        (field @"cfgHLintYaml")
-        ^^^ metahelp "PATH" "Use specific .hlint.yaml"
+        ^^^ metaActionHelp "PATH" "file" "Use specific .hlint.yaml"
     <*> C.monoidalFieldAla "hlint-options" (C.alaList' C.NoCommaFSep C.Token') (field @"cfgHLintOptions")
         ^^^ metahelp "OPTS" "Additional HLint options"
     <*> C.optionalFieldDef "hlint-version"                                     (field @"cfgHLintVersion") defaultHLintVersion

--- a/src/HaskellCI/OptionsGrammar.hs
+++ b/src/HaskellCI/OptionsGrammar.hs
@@ -8,6 +8,7 @@ module HaskellCI.OptionsGrammar (
     OptionsGrammar (..),
     (C.^^^),
     ParsecPretty,
+    Help, MetaVar, BashCompletionAction
 )  where
 
 import HaskellCI.Prelude
@@ -22,6 +23,19 @@ import qualified Distribution.Types.VersionRange as C
 
 import HaskellCI.Newtypes
 
+-- | Help text for option.
+type Help    = String
+
+-- | Meta variable for option argument.
+type MetaVar = String
+
+-- | Bash completion action for option argument.
+--   Example: @"file"@ or @"directory"@.
+--
+-- See <https://github.com/pcapriotti/optparse-applicative#actions-and-completers>
+-- and <https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html>.
+type BashCompletionAction = String
+
 class
     ( C.FieldGrammar c p
     , c Range, c (Identity C.VersionRange)
@@ -35,10 +49,13 @@ class
     )
     => OptionsGrammar c p | p -> c
   where
-    metahelp :: String -> String -> p s a -> p s a
+    metaActionHelp :: MetaVar -> BashCompletionAction -> Help -> p s a -> p s a
+    metaActionHelp _ _ _ = id
+
+    metahelp :: MetaVar -> Help -> p s a -> p s a
     metahelp _ _ = id
 
-    help :: String -> p s a -> p s a
+    help :: Help -> p s a -> p s a
     help _ = id
 
     -- we treat range fields specially in options

--- a/src/HaskellCI/OptparseGrammar.hs
+++ b/src/HaskellCI/OptparseGrammar.hs
@@ -25,14 +25,14 @@ import qualified Options.Applicative         as O
 import HaskellCI.OptionsGrammar
 
 data SomeParser s where
-    SP :: (Maybe String -> Maybe String -> O.Parser (s -> s)) -> SomeParser s
+    SP :: (Maybe MetaVar -> Maybe BashCompletionAction -> Maybe Help -> O.Parser (s -> s)) -> SomeParser s
 
 newtype OptparseGrammar s a = OG [SomeParser s]
   deriving Functor
 
 runOptparseGrammar :: OptparseGrammar s a -> O.Parser (s -> s)
 runOptparseGrammar (OG ps) = fmap (foldr (flip (.)) id) $ many $ asum
-    [ p Nothing Nothing
+    [ p Nothing Nothing Nothing
     | SP p <- ps
     ]
 
@@ -42,7 +42,7 @@ instance Applicative (OptparseGrammar s) where
 
 instance C.FieldGrammar ParsecPretty OptparseGrammar where
     blurFieldGrammar l (OG ps) = OG
-        [ SP $ \v h -> fmap (l C.#%~) (p v h)
+        [ SP $ \v a h -> fmap (l C.#%~) (p v a h)
         | SP p <- ps
         ]
 
@@ -51,23 +51,23 @@ instance C.FieldGrammar ParsecPretty OptparseGrammar where
 
     -- the non default flag has help entry
     booleanFieldDef fn l def = OG
-        [ SP $ \_m h -> setOG l $ O.flag' True  $ flagMods fn (th h)
-        , SP $ \_m h -> setOG l $ O.flag' False $ flagMods ("no-" <> fn) (fh h)
+        [ SP $ \_m _a h -> setOG l $ O.flag' True  $ flagMods fn (th h)
+        , SP $ \_m _a h -> setOG l $ O.flag' False $ flagMods ("no-" <> fn) (fh h)
         ]
       where
         th h = if def then Nothing else h
         fh h = if def then h else Nothing
 
     optionalFieldAla fn c l = OG
-        [ SP $ \m h -> setOptionalOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m h ]
+        [ SP $ \m a h -> setOptionalOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m a h ]
 
     optionalFieldDefAla fn c l def = OG
-        [ SP $ \m h -> setOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m (fmap hdef h) ]
+        [ SP $ \m a h -> setOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m a (fmap hdef h) ]
       where
         hdef h = h ++ " (Default: " ++ C.prettyShow (C.pack' c def) ++ ")"
 
     monoidalFieldAla fn c l = OG
-        [ SP $ \m h -> monoidOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m h ]
+        [ SP $ \m a h -> monoidOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m a h ]
 
     prefixedFields _ _   = pure []
     knownField _         = pure ()
@@ -77,22 +77,27 @@ instance C.FieldGrammar ParsecPretty OptparseGrammar where
     hiddenField          = id
 
     freeTextField fn l = OG
-        [ SP $ \m h -> setOptionalOG l $ O.strOption $ optionMods fn m h ]
+        [ SP $ \m a h -> setOptionalOG l $ O.strOption $ optionMods fn m a h ]
 
     freeTextFieldDef fn l = OG
-        [ SP $ \m h -> setOG l $ O.strOption $ optionMods fn m h ]
+        [ SP $ \m a h -> setOG l $ O.strOption $ optionMods fn m a h ]
 
     freeTextFieldDefST fn l = OG
-        [ SP $ \m h -> setOG l $ O.strOption $ optionMods fn m h ]
+        [ SP $ \m a h -> setOG l $ O.strOption $ optionMods fn m a h ]
 
 instance OptionsGrammar ParsecPretty OptparseGrammar where
     help h (OG ps) = OG
-        [ SP $ \m _h -> p m (Just h)
+        [ SP $ \m a _h -> p m a (Just h)
         | SP p <- ps
         ]
 
     metahelp m h (OG ps) = OG
-        [ SP $ \_m _h -> p (Just m) (Just h)
+        [ SP $ \_m a _h -> p (Just m) a (Just h)
+        | SP p <- ps
+        ]
+
+    metaActionHelp m a h (OG ps) = OG
+        [ SP $ \_m _a _h -> p (Just m) (Just a) (Just h)
         | SP p <- ps
         ]
 
@@ -105,19 +110,21 @@ instance OptionsGrammar ParsecPretty OptparseGrammar where
     -- where the --no-tests has help, because it's not default.
     --
     rangeField fn l def = OG
-        [ SP $ \_m  h -> setOG l $ O.flag' C.anyVersion $ flagMods fn (th h)
-        , SP $ \_m  h -> setOG l $ O.flag' C.noVersion  $ flagMods ("no-" <> fn) (fh h)
-        , SP $ \_m _h -> setOG l $ O.option readMParsec $ O.long (fromUTF8BS $ fn <> "-jobs") <> O.metavar "RANGE"
+        [ SP $ \_m _a  h -> setOG l $ O.flag' C.anyVersion $ flagMods fn (th h)
+        , SP $ \_m _a  h -> setOG l $ O.flag' C.noVersion  $ flagMods ("no-" <> fn) (fh h)
+        , SP $ \_m _a _h -> setOG l $ O.option readMParsec $ O.long (fromUTF8BS $ fn <> "-jobs") <> O.metavar "RANGE"
         ]
       where
         th h = if equivVersionRanges def C.anyVersion then Nothing else h
         fh h = if equivVersionRanges def C.anyVersion then h else Nothing
 
-optionMods :: (O.HasName mods, O.HasMetavar mods) => C.FieldName -> Maybe String -> Maybe String -> O.Mod mods a
-optionMods fn mmetavar mhelp = flagMods fn mhelp
+optionMods :: (O.HasName mods, O.HasCompleter mods, O.HasMetavar mods)
+           => C.FieldName -> Maybe MetaVar -> Maybe BashCompletionAction -> Maybe Help -> O.Mod mods a
+optionMods fn mmetavar mact mhelp = flagMods fn mhelp
     <> maybe mempty O.metavar mmetavar
+    <> maybe mempty O.action  mact
 
-flagMods :: O.HasName mods => C.FieldName -> Maybe String -> O.Mod mods a
+flagMods :: O.HasName mods => C.FieldName -> Maybe Help -> O.Mod mods a
 flagMods fn mhelp = O.long (fromUTF8BS fn)
     <> maybe mempty O.help mhelp
 

--- a/src/HaskellCI/OptparseGrammar.hs
+++ b/src/HaskellCI/OptparseGrammar.hs
@@ -25,7 +25,7 @@ import qualified Options.Applicative         as O
 import HaskellCI.OptionsGrammar
 
 data SomeParser s where
-    SP :: (Maybe MetaVar -> Maybe BashCompletionAction -> Maybe Help -> O.Parser (s -> s)) -> SomeParser s
+    SP :: (Maybe MetaVar -> Maybe O.Completer -> Maybe Help -> O.Parser (s -> s)) -> SomeParser s
 
 newtype OptparseGrammar s a = OG [SomeParser s]
   deriving Functor
@@ -42,7 +42,7 @@ instance Applicative (OptparseGrammar s) where
 
 instance C.FieldGrammar ParsecPretty OptparseGrammar where
     blurFieldGrammar l (OG ps) = OG
-        [ SP $ \v a h -> fmap (l C.#%~) (p v a h)
+        [ SP $ \v c h -> fmap (l C.#%~) (p v c h)
         | SP p <- ps
         ]
 
@@ -51,23 +51,23 @@ instance C.FieldGrammar ParsecPretty OptparseGrammar where
 
     -- the non default flag has help entry
     booleanFieldDef fn l def = OG
-        [ SP $ \_m _a h -> setOG l $ O.flag' True  $ flagMods fn (th h)
-        , SP $ \_m _a h -> setOG l $ O.flag' False $ flagMods ("no-" <> fn) (fh h)
+        [ SP $ \_m _c h -> setOG l $ O.flag' True  $ flagMods fn (th h)
+        , SP $ \_m _c h -> setOG l $ O.flag' False $ flagMods ("no-" <> fn) (fh h)
         ]
       where
         th h = if def then Nothing else h
         fh h = if def then h else Nothing
 
     optionalFieldAla fn c l = OG
-        [ SP $ \m a h -> setOptionalOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m a h ]
+        [ SP $ \m cpl h -> setOptionalOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m cpl h ]
 
     optionalFieldDefAla fn c l def = OG
-        [ SP $ \m a h -> setOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m a (fmap hdef h) ]
+        [ SP $ \m cpl h -> setOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m cpl (fmap hdef h) ]
       where
         hdef h = h ++ " (Default: " ++ C.prettyShow (C.pack' c def) ++ ")"
 
     monoidalFieldAla fn c l = OG
-        [ SP $ \m a h -> monoidOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m a h ]
+        [ SP $ \m cpl h -> monoidOG l $ O.option (C.unpack' c <$> readMParsec) $ optionMods fn m cpl h ]
 
     prefixedFields _ _   = pure []
     knownField _         = pure ()
@@ -77,27 +77,27 @@ instance C.FieldGrammar ParsecPretty OptparseGrammar where
     hiddenField          = id
 
     freeTextField fn l = OG
-        [ SP $ \m a h -> setOptionalOG l $ O.strOption $ optionMods fn m a h ]
+        [ SP $ \m c h -> setOptionalOG l $ O.strOption $ optionMods fn m c h ]
 
     freeTextFieldDef fn l = OG
-        [ SP $ \m a h -> setOG l $ O.strOption $ optionMods fn m a h ]
+        [ SP $ \m c h -> setOG l $ O.strOption $ optionMods fn m c h ]
 
     freeTextFieldDefST fn l = OG
-        [ SP $ \m a h -> setOG l $ O.strOption $ optionMods fn m a h ]
+        [ SP $ \m c h -> setOG l $ O.strOption $ optionMods fn m c h ]
 
 instance OptionsGrammar ParsecPretty OptparseGrammar where
     help h (OG ps) = OG
-        [ SP $ \m a _h -> p m a (Just h)
+        [ SP $ \m c _h -> p m c (Just h)
         | SP p <- ps
         ]
 
     metahelp m h (OG ps) = OG
-        [ SP $ \_m a _h -> p (Just m) a (Just h)
+        [ SP $ \_m c _h -> p (Just m) c (Just h)
         | SP p <- ps
         ]
 
     metaActionHelp m a h (OG ps) = OG
-        [ SP $ \_m _a _h -> p (Just m) (Just a) (Just h)
+        [ SP $ \_m _c _h -> p (Just m) (Just $ O.bashCompleter a) (Just h)
         | SP p <- ps
         ]
 
@@ -110,19 +110,19 @@ instance OptionsGrammar ParsecPretty OptparseGrammar where
     -- where the --no-tests has help, because it's not default.
     --
     rangeField fn l def = OG
-        [ SP $ \_m _a  h -> setOG l $ O.flag' C.anyVersion $ flagMods fn (th h)
-        , SP $ \_m _a  h -> setOG l $ O.flag' C.noVersion  $ flagMods ("no-" <> fn) (fh h)
-        , SP $ \_m _a _h -> setOG l $ O.option readMParsec $ O.long (fromUTF8BS $ fn <> "-jobs") <> O.metavar "RANGE"
+        [ SP $ \_m _c  h -> setOG l $ O.flag' C.anyVersion $ flagMods fn (th h)
+        , SP $ \_m _c  h -> setOG l $ O.flag' C.noVersion  $ flagMods ("no-" <> fn) (fh h)
+        , SP $ \_m _c _h -> setOG l $ O.option readMParsec $ O.long (fromUTF8BS $ fn <> "-jobs") <> O.metavar "RANGE"
         ]
       where
         th h = if equivVersionRanges def C.anyVersion then Nothing else h
         fh h = if equivVersionRanges def C.anyVersion then h else Nothing
 
 optionMods :: (O.HasName mods, O.HasCompleter mods, O.HasMetavar mods)
-           => C.FieldName -> Maybe MetaVar -> Maybe BashCompletionAction -> Maybe Help -> O.Mod mods a
-optionMods fn mmetavar mact mhelp = flagMods fn mhelp
+           => C.FieldName -> Maybe MetaVar -> Maybe O.Completer -> Maybe Help -> O.Mod mods a
+optionMods fn mmetavar mcompl mhelp = flagMods fn mhelp
     <> maybe mempty O.metavar mmetavar
-    <> maybe mempty O.action  mact
+    <> maybe mempty O.completer mcompl
 
 flagMods :: O.HasName mods => C.FieldName -> Maybe Help -> O.Mod mods a
 flagMods fn mhelp = O.long (fromUTF8BS fn)


### PR DESCRIPTION
# Fix #487: enable bash-completion for file and directories

`optparse-applicative` supports bash-completion.  For this to work,
completers have to be supplied with option arguments, in particular

  - `action "file"` for FILE arguments
  - `action "directory"` for DIR arguments

This patch adds the necessary `action`s

  - directly to the option compositions (`O.strOption` ...)
  - via `metaActionHelp` to the options generated through the `OptparseGrammar`

This fixes bash-completion for haskell-ci, e.g.
```
  haskell-ci git<TAB>
  haskell-ci github
  haskell-ci github ha<TAB>
  haskell-ci github haskell-ci.cabal
  haskell-ci github haskell-ci.cabal --hl<TAB>
  haskell-ci github haskell-ci.cabal --hlint
  haskell-ci github haskell-ci.cabal --hlint-y<TAB>
  haskell-ci github haskell-ci.cabal --hlint-yaml
  haskell-ci github haskell-ci.cabal --hlint-yaml hl<TAB>
  haskell-ci github haskell-ci.cabal --hlint-yaml hlint.yaml
```