### PR TITLE
GHA: Support --distribution and --submodules

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -48,7 +48,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:focal
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -21,7 +21,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
@@ -128,7 +128,7 @@ jobs:
           apt-add-repository -y 'ppa:hvr/ghc'
           if [ $((GHCJSARITH)) -ne 0 ] ; then apt-add-repository -y 'ppa:hvr/ghcjs' ; fi
           if [ $((GHCJSARITH)) -ne 0 ] ; then curl -sSL "https://deb.nodesource.com/gpgkey/nodesource.gpg.key" | apt-key add - ; fi
-          if [ $((GHCJSARITH)) -ne 0 ] ; then apt-add-repository -y 'deb https://deb.nodesource.com/node_10.x bionic main' ; fi
+          if [ $((GHCJSARITH)) -ne 0 ] ; then apt-add-repository -y 'deb https://deb.nodesource.com/node_10.x xenial main' ; fi
           apt-get update
           if [ $((GHCJSARITH)) -ne 0 ] ; then apt-get install -y $CC cabal-install-3.4 ghc-8.4.4 nodejs ; else apt-get install -y $CC cabal-install-3.4 ; fi
         env:

--- a/fixtures/copy-fields-all.github
+++ b/fixtures/copy-fields-all.github
@@ -21,7 +21,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/fixtures/copy-fields-none.github
+++ b/fixtures/copy-fields-none.github
@@ -21,7 +21,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/fixtures/copy-fields-some.github
+++ b/fixtures/copy-fields-some.github
@@ -21,7 +21,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/fixtures/empty-line.github
+++ b/fixtures/empty-line.github
@@ -21,7 +21,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/fixtures/irc-channels.github
+++ b/fixtures/irc-channels.github
@@ -46,7 +46,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/fixtures/messy.github
+++ b/fixtures/messy.github
@@ -21,7 +21,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/fixtures/psql.github
+++ b/fixtures/psql.github
@@ -21,7 +21,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     services:
       postgres:
         image: postgres:10

--- a/fixtures/travis-patch.github
+++ b/fixtures/travis-patch.github
@@ -21,7 +21,7 @@ jobs:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -88,6 +88,7 @@ library haskell-ci-internal
     HaskellCI.Config.Jobs
     HaskellCI.Config.PackageScope
     HaskellCI.Config.Ubuntu
+    HaskellCI.Config.Validity
     HaskellCI.Diagnostics
     HaskellCI.GitConfig
     HaskellCI.GitHub

--- a/src/HaskellCI/Bash.hs
+++ b/src/HaskellCI/Bash.hs
@@ -22,6 +22,7 @@ import HaskellCI.Config.ConstraintSet
 import HaskellCI.Config.Doctest
 import HaskellCI.Config.Installed
 import HaskellCI.Config.PackageScope
+import HaskellCI.Config.Validity
 import HaskellCI.Jobs
 import HaskellCI.List
 import HaskellCI.Package
@@ -43,6 +44,9 @@ makeBash
     -> JobVersions
     -> Either ShError Z -- TODO: writer
 makeBash _argv config@Config {..} prj jobs@JobVersions {..} = do
+    -- Validity checks
+    checkConfigValidity config jobs
+
     blocks <- traverse (fmap shsToList) $ buildList $ do
         -- install doctest
         when doctestEnabled $ step "install doctest" $ do

--- a/src/HaskellCI/Config/Validity.hs
+++ b/src/HaskellCI/Config/Validity.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+module HaskellCI.Config.Validity where
+
+import HaskellCI.Prelude
+
+import HaskellCI.Compiler
+import HaskellCI.Config
+import HaskellCI.Config.Ubuntu
+import HaskellCI.Jobs
+import HaskellCI.MonadErr
+import HaskellCI.Sh
+
+-- Validity checks shared in common among all backends.
+checkConfigValidity :: MonadErr ShError m => Config -> JobVersions -> m ()
+checkConfigValidity Config {..} JobVersions {..} = do
+    when (anyGHCJS && cfgUbuntu > Bionic) $
+        throwErr $ ShError $ "Using GHCJS requires Ubuntu 16.04 (Xenial) or 18.04 (Bionic)."
+  where
+    anyGHCJS = any isGHCJS versions

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -36,6 +36,7 @@ import HaskellCI.Config.HLint
 import HaskellCI.Config.Installed
 import HaskellCI.Config.PackageScope
 import HaskellCI.Config.Ubuntu
+import HaskellCI.Config.Validity
 import HaskellCI.GitConfig
 import HaskellCI.GitHub.Yaml
 import HaskellCI.HeadHackage
@@ -100,6 +101,8 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
             [ ("CC", "${{ matrix.compiler }}")
             ]
 
+    -- Validity checks
+    checkConfigValidity config jobs
     when (cfgSubmodules && cfgUbuntu < Focal) $
         throwErr $ ShError $ "Using submodules on the GitHub Actions backend requires "
                           ++ "Ubuntu 20.04 (Focal Fossa) or later."

--- a/src/HaskellCI/Travis.hs
+++ b/src/HaskellCI/Travis.hs
@@ -29,6 +29,7 @@ import HaskellCI.Config.HLint
 import HaskellCI.Config.Installed
 import HaskellCI.Config.Jobs
 import HaskellCI.Config.PackageScope
+import HaskellCI.Config.Validity
 import HaskellCI.HeadHackage
 import HaskellCI.Jobs
 import HaskellCI.List
@@ -93,6 +94,9 @@ makeTravis argv config@Config {..} prj jobs@JobVersions {..} = do
 
     -- before install: we set up the environment, install GHC/cabal on OSX
     beforeInstall <- runSh $ do
+        -- Validity checks
+        checkConfigValidity config jobs
+
         -- This have to be first
         when anyGHCJS $ sh $ unlines
             [ "if echo $CC | grep -q ghcjs; then"


### PR DESCRIPTION
The `checkout` action requires Git 2.18 or later to function properly, so this is only available with Ubuntu 20.04 (Focal) or later.

Fixes #503.