### PR TITLE
Install libnuma-dev for ghcup's benefit

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.14.1/x86_64-linux-ghcup-0.1.14.1 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -254,7 +254,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           if [ $((GHCJSARITH)) -ne 0 ] ; then apt-add-repository -y 'ppa:hvr/ghcjs' ; fi
           if [ $((GHCJSARITH)) -ne 0 ] ; then curl -sSL "https://deb.nodesource.com/gpgkey/nodesource.gpg.key" | apt-key add - ; fi

--- a/fixtures/copy-fields-all.github
+++ b/fixtures/copy-fields-all.github
@@ -171,7 +171,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
           apt-get install -y "$HCNAME" cabal-install-3.4

--- a/fixtures/copy-fields-none.github
+++ b/fixtures/copy-fields-none.github
@@ -171,7 +171,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
           apt-get install -y "$HCNAME" cabal-install-3.4

--- a/fixtures/copy-fields-some.github
+++ b/fixtures/copy-fields-some.github
@@ -171,7 +171,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
           apt-get install -y "$HCNAME" cabal-install-3.4

--- a/fixtures/empty-line.github
+++ b/fixtures/empty-line.github
@@ -171,7 +171,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
           apt-get install -y "$HCNAME" cabal-install-3.4

--- a/fixtures/enabled-jobs.github
+++ b/fixtures/enabled-jobs.github
@@ -164,7 +164,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           if [ $((GHCJSARITH)) -ne 0 ] ; then apt-add-repository -y 'ppa:hvr/ghcjs' ; fi
           if [ $((GHCJSARITH)) -ne 0 ] ; then curl -sSL "https://deb.nodesource.com/gpgkey/nodesource.gpg.key" | apt-key add - ; fi

--- a/fixtures/irc-channels.github
+++ b/fixtures/irc-channels.github
@@ -196,7 +196,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
           apt-get install -y "$HCNAME" cabal-install-3.4

--- a/fixtures/messy.github
+++ b/fixtures/messy.github
@@ -171,7 +171,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
           apt-get install -y "$HCNAME" cabal-install-3.4 fftw3-dev

--- a/fixtures/psql.github
+++ b/fixtures/psql.github
@@ -177,7 +177,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
           apt-get install -y "$HCNAME" cabal-install-3.4

--- a/fixtures/travis-patch.github
+++ b/fixtures/travis-patch.github
@@ -171,7 +171,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
           apt-get install -y "$HCNAME" cabal-install-3.4

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.13.20210529
+version:            0.13.20210530
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -127,7 +127,9 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
 
         githubRun' "apt" envEnv $ do
             sh "apt-get update"
-            sh "apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5" -- libnuma-dev?
+            -- Installing libnuma-dev is required to work around
+            -- https://gitlab.haskell.org/haskell/ghcup-hs/-/blob/b0522507be6fa991a819aaf22f9a551757380821/README.md#libnuma-required
+            sh "apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev"
 
             hvrppa <- runSh $ do
                 sh "apt-add-repository -y 'ppa:hvr/ghc'"


### PR DESCRIPTION
This is needed to work around a bug that occurs when installing GHC 8.4.4 by way of `ghcup`. See https://gitlab.haskell.org/haskell/ghcup-hs/-/blob/b0522507be6fa991a819aaf22f9a551757380821/README.md#libnuma-required.

Fixes #516.