### PR TITLE
Remove uses of allow-newer from cabal.project

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -220,20 +220,13 @@ jobs:
             ghc-options: -Werror=missing-methods
           EOF
           cat >> cabal.project <<EOF
-          allow-newer: cryptohash-sha256:base
-          allow-newer: generic-lens-lite:base
-          allow-newer: HsYAML:base
-          allow-newer: cassava-0.5.2.0:base
-          allow-newer: vector-th-unbox-0.2.1.7:base
-          allow-newer: vector-th-unbox-0.2.1.7:template-haskell
-
           package haskell-ci
             ghc-options: -Werror
 
           package cabal-install-parsers
             ghc-options: -Werror
 
-          keep-going:  False
+          keep-going: False
 
           package bytestring
             tests: False

--- a/cabal.project
+++ b/cabal.project
@@ -6,10 +6,3 @@ tests: True
 package haskell-ci
   ghc-options: -Wall
   ghc-options: -Werror
-
-allow-newer: cryptohash-sha256:base
-allow-newer: generic-lens-lite:base
-allow-newer: HsYAML:base
-allow-newer: cassava-0.5.2.0:base
-allow-newer: vector-th-unbox-0.2.1.7:base
-allow-newer: vector-th-unbox-0.2.1.7:template-haskell

--- a/haskell-ci.sh
+++ b/haskell-ci.sh
@@ -482,20 +482,13 @@ package *
   ghc-options: -Werror=missing-methods
 EOF
 cat >> cabal.project <<EOF
-allow-newer: cryptohash-sha256:base
-allow-newer: generic-lens-lite:base
-allow-newer: HsYAML:base
-allow-newer: cassava-0.5.2.0:base
-allow-newer: vector-th-unbox-0.2.1.7:base
-allow-newer: vector-th-unbox-0.2.1.7:template-haskell
-
 package haskell-ci
   ghc-options: -Werror
 
 package cabal-install-parsers
   ghc-options: -Werror
 
-keep-going:  False
+keep-going: False
 
 package bytestring
   tests: False


### PR DESCRIPTION
The latest Hackage versions of these libraries all support GHC 9.0.