### PR TITLE
Respect CABAL_DIR in 'resolveConfig'

### DIFF
--- a/cabal-install-parsers/src/Cabal/Config.hs
+++ b/cabal-install-parsers/src/Cabal/Config.hs
@@ -74,9 +74,14 @@ findConfig = do
     case env of
         Just p -> return p
         Nothing -> do
-            cabalDirVar <- lookupEnv "CABAL_DIR"
-            cabalDir <- maybe (getAppUserDataDirectory "cabal") return cabalDirVar
+            cabalDir <- findCabalDir
             return (cabalDir </> "config")
+
+-- | Find the @~\/.cabal@ dir.
+findCabalDir :: IO FilePath
+findCabalDir = do
+    cabalDirVar <- lookupEnv "CABAL_DIR"
+    maybe (getAppUserDataDirectory "cabal") return cabalDirVar
 
 -------------------------------------------------------------------------------
 -- Config
@@ -174,7 +179,7 @@ repoGrammar = Repo
 -- | Fill the default in @~\/.cabal\/config@  file.
 resolveConfig :: Config Maybe -> IO (Config Identity)
 resolveConfig cfg = do
-    c <- getAppUserDataDirectory "cabal"
+    c <- findCabalDir
     return cfg
         { cfgRemoteRepoCache = Identity $ fromMaybe (c </> "packages") (cfgRemoteRepoCache cfg)
         , cfgInstallDir      = Identity $ fromMaybe (c </> "bin")      (cfgInstallDir cfg)


### PR DESCRIPTION
Although 'findConfig' already respects it, 'resolveConfig' will
try to fill in missing values by examining 'getAppUserDataDirectory',
ignoring CABAL_DIR and possibly picking a wrong path for 'cfgStoreDir'.

This causes failures in e.g. cabal-docspec: https://gitlab.haskell.org/haskell/ghcup-hs/-/jobs/770892#L2501

----

It should also be backported to pre-Cabal-3.6, so we can build a `cabal-docspec` that includes it.