### PR TITLE
Bump doctest default & hardcoded versions for GHC 9.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -197,7 +197,7 @@ jobs:
           cabal-docspec --version
       - name: install doctest
         run: |
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.17' ; fi
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.20' ; fi
           if [ $((HCNUMVER < 90000)) -ne 0 ] ; then doctest --version ; fi
       - name: install hlint
         run: |

--- a/haskell-ci.sh
+++ b/haskell-ci.sh
@@ -447,7 +447,7 @@ run_cmd cabal-plan --version
 # install doctest
 put_info "install doctest"
 # install doctest
-run_cmd_if $((HCNUMVER < 90000)) $CABAL v2-install $ARG_COMPILER --ignore-project -j doctest --constraint='doctest ^>=0.17'
+run_cmd_if $((HCNUMVER < 90000)) $CABAL v2-install $ARG_COMPILER --ignore-project -j doctest --constraint='doctest ^>=0.20'
 run_cmd_if $((HCNUMVER < 90000)) doctest --version
 
 # initial cabal.project for sdist

--- a/src/HaskellCI/Bash.hs
+++ b/src/HaskellCI/Bash.hs
@@ -52,7 +52,7 @@ makeBash _argv config@Config {..} prj jobs@JobVersions {..} = do
         when doctestEnabled $ step "install doctest" $ do
             let range = Range (cfgDoctestEnabled cfgDoctest) /\ doctestJobVersionRange
             comment "install doctest"
-            run_cmd_if range "$CABAL v2-install $ARG_COMPILER --ignore-project -j doctest --constraint='doctest ^>=0.17'"
+            run_cmd_if range "$CABAL v2-install $ARG_COMPILER --ignore-project -j doctest --constraint='doctest ^>=0.20'"
             run_cmd_if range "doctest --version"
 
         -- install hlint

--- a/src/HaskellCI/Config/Doctest.hs
+++ b/src/HaskellCI/Config/Doctest.hs
@@ -26,7 +26,7 @@ data DoctestConfig = DoctestConfig
 -------------------------------------------------------------------------------
 
 defaultDoctestVersion :: VersionRange
-defaultDoctestVersion = majorBoundVersion (mkVersion [0,18,1])
+defaultDoctestVersion = majorBoundVersion (mkVersion [0,20,0])
 
 -------------------------------------------------------------------------------
 -- Grammar

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -334,7 +334,7 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
 
         when doctestEnabled $ githubRun "install doctest" $ do
             let range = Range (cfgDoctestEnabled cfgDoctest) /\ doctestJobVersionRange
-            sh_if range "$CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.17'"
+            sh_if range "$CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.20'"
             sh_if range "doctest --version"
 
         let hlintVersionConstraint


### PR DESCRIPTION
The current default doctest version doesn't work with GHC 9.2. The latest version supports all the GHCs we need, so I've updated the default version and everywhere that a doctest constraint is formed.