### PR TITLE
Print jobs-selection: any jobs in a table

### DIFF
--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -137,7 +137,7 @@ copy-fields: some
 --            tested-with stanza. (Default)
 --   any:     Take the union of all packages' version ranges. This implies
 --            that different packages' version ranges can be disjoint.
-jobs-selection: any
+jobs-selection: uniform
 
 -- Controls whether the haskell-ci version should be inserted into the
 -- generated Travis YAML file. (Default: True)


### PR DESCRIPTION
For example:

```
*INFO* Generating GitHub config for testing for GHC versions: 7.4.2 7.6.3 7.8.4 7.10.3 8.0.2 8.2.2 8.4.4 8.6.5 8.8.4 8.10.4 9.0.1 9.2.1 ghcjs-8.4
*INFO* these            7.4.2 7.6.3 7.8.4 7.10.3 8.0.2 8.2.2 8.4.4 8.6.5 8.8.4 8.10.4 9.0.1 9.2.1 ghcjs-8.4
*INFO* these-lens       7.4.2 7.6.3 7.8.4 7.10.3 8.0.2 8.2.2 8.4.4 8.6.5 8.8.4 8.10.4 9.0.1 9.2.1 ghcjs-8.4
*INFO* these-optics                              8.0.2 8.2.2 8.4.4 8.6.5 8.8.4 8.10.4 9.0.1 9.2.1 ghcjs-8.4
*INFO* semialign        7.4.2 7.6.3 7.8.4 7.10.3 8.0.2 8.2.2 8.4.4 8.6.5 8.8.4 8.10.4 9.0.1 9.2.1 ghcjs-8.4
*INFO* monad-chronicle  7.4.2 7.6.3 7.8.4 7.10.3 8.0.2 8.2.2 8.4.4 8.6.5 8.8.4 8.10.4 9.0.1 9.2.1 ghcjs-8.4
*INFO* these-tests      7.4.2 7.6.3 7.8.4 7.10.3 8.0.2 8.2.2 8.4.4 8.6.5 8.8.4 8.10.4 9.0.1 9.2.1 ghcjs-8.4
```

Hopefully makes it easier to check whether there are no mistakes.