### PR TITLE
Fix help text for --distribution in a future proof way

### DIFF
--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -142,7 +142,11 @@ configGrammar = Config
     <*> C.optionalField       "jobs"                                                          (field @"cfgJobs")
         ^^^ metahelp "JOBS" "jobs (N:M - cabal:ghc)"
     <*> C.optionalFieldDef    "distribution"                                                  (field @"cfgUbuntu") Bionic
-        ^^^ metahelp "DIST" "distribution version (xenial, bionic)"
+        ^^^ metahelp "DIST" (concat
+              [ "distribution version ("
+              , intercalate ", " $ map showUbuntu [minBound..maxBound]
+              , ")"
+              ])
     <*> C.optionalFieldDef    "jobs-selection"                                                (field @"cfgTestedWith") TestedWithUniform
         ^^^ metahelp "uniform|any" "Jobs selection across packages"
     <*> rangeField            "enabled"                                                       (field @"cfgEnabledJobs") anyVersion

--- a/src/HaskellCI/Config/Ubuntu.hs
+++ b/src/HaskellCI/Config/Ubuntu.hs
@@ -7,7 +7,7 @@ import qualified Distribution.Pretty as C
 import qualified Text.PrettyPrint    as PP
 
 data Ubuntu = Xenial | Bionic | Focal
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Enum, Bounded)
 
 instance C.Parsec Ubuntu where
     parsec = do


### PR DESCRIPTION
Fix help text for --distribution in a future proof way.

Before:
```
  --distribution DIST      distribution version (xenial, bionic)
```
After:
```
  --distribution DIST      distribution version (xenial, bionic, focal)
```