### PR TITLE
Don't unconditionally force allow-failure with head.hackage

### DIFF
--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -176,7 +176,7 @@ configGrammar = Config
     <*> rangeField            "unconstrained"                                                 (field @"cfgUnconstrainted") anyVersion
         ^^^ metahelp "RANGE" "Make unconstrained build"
     <*> rangeField            "head-hackage"                                                  (field @"cfgHeadHackage") defaultHeadHackage
-        ^^^ metahelp "RANGE" "Use head.hackage repository. Also marks as allow-failures"
+        ^^^ metahelp "RANGE" "Use head.hackage repository"
     <*> C.booleanFieldDef     "ghcjs-tests"                                                   (field @"cfgGhcjsTests") False
         ^^^ help "Run tests with GHCJS (experimental, relies on cabal-plan finding test-suites)"
     <*> C.monoidalFieldAla    "ghcjs-tools"               (C.alaList C.FSep)                  (field @"cfgGhcjsTools")

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -623,8 +623,7 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
                     [ GitHubMatrixEntry
                         { ghmeCompiler     = translateCompilerVersion $ compiler
                         , ghmeAllowFailure =
-                               previewGHC cfgHeadHackage compiler
-                            || maybeGHC False (`C.withinRange` cfgAllowFailures) compiler
+                               maybeGHC False (`C.withinRange` cfgAllowFailures) compiler
                         , ghmeSetupMethod = if isGHCUP compiler then GHCUP else HVRPPA
                         }
                     | compiler <- reverse $ toList linuxVersions


### PR DESCRIPTION
I was surprised that it is like this since there's `allow-failures` for configuring which versions you want to allow failures for.

Generally, once the program compiles with pre-released GHC, I'd expect it to continue compiling so it's nice to be able to say that you want to see the failure if it occurs.
