### PR TITLE
Haskell-CI 0.15.20220710: Bump GHC 9.4.1 to alpha3

### DIFF
--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -33,9 +33,9 @@ jobs:
             compilerVersion: "8.4"
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-9.4.0.20220523
+          - compiler: ghc-9.4.0.20220623
             compilerKind: ghc
-            compilerVersion: 9.4.0.20220523
+            compilerVersion: 9.4.0.20220623
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.2.3

--- a/fixtures/enabled-jobs.github
+++ b/fixtures/enabled-jobs.github
@@ -33,9 +33,9 @@ jobs:
             compilerVersion: "8.4"
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-9.4.0.20220523
+          - compiler: ghc-9.4.0.20220623
             compilerKind: ghc
-            compilerVersion: 9.4.0.20220523
+            compilerVersion: 9.4.0.20220623
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.2.3

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.15.20220620
+version:            0.15.20220710
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for

--- a/src/HaskellCI/Compiler.hs
+++ b/src/HaskellCI/Compiler.hs
@@ -182,7 +182,7 @@ dispCabalVersion :: Maybe Version -> String
 dispCabalVersion = maybe "head" C.prettyShow
 
 ghcAlpha :: Maybe (Version, Version)
-ghcAlpha = Just (mkVersion [9,4,1], mkVersion [9,4,0,20220523])
+ghcAlpha = Just (mkVersion [9,4,1], mkVersion [9,4,0,20220623])
 
 -- | Alphas, RCs and HEAD.
 previewGHC


### PR DESCRIPTION
Tested here:  https://github.com/phile314/tasty-silver/runs/7272864733?check_suite_focus=true