### PR TITLE
Update default hlint version to ^>=3.4

### DIFF
--- a/src/HaskellCI/Config/HLint.hs
+++ b/src/HaskellCI/Config/HLint.hs
@@ -31,7 +31,7 @@ data HLintConfig = HLintConfig
 -------------------------------------------------------------------------------
 
 defaultHLintVersion :: VersionRange
-defaultHLintVersion = withinVersion (mkVersion [3,3])
+defaultHLintVersion = withinVersion (mkVersion [3,4])
 
 -------------------------------------------------------------------------------
 -- HLintJob


### PR DESCRIPTION
hlint-3.3.6 has a bug
(https://github.com/ndmitchell/hlint/issues/1360), which was fixed
in v3.4.