### PR TITLE
Keep the IRC Ubuntu version in sync with the main job's version

### DIFF
--- a/fixtures/irc-channels.github
+++ b/fixtures/irc-channels.github
@@ -19,7 +19,7 @@ on:
 jobs:
   irc:
     name: Haskell-CI (IRC notification)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - linux
     if: ${{ always() }}

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.15.20220808
+version:            0.15.20220812
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -609,7 +609,7 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
                 { ghjName            = actionName ++ " - Linux - ${{ matrix.compiler }}"
                   -- NB: The Ubuntu version used in `runs-on` isn't
                   -- particularly important since we use a Docker container.
-                , ghjRunsOn          = "ubuntu-20.04"
+                , ghjRunsOn          = ghcRunsOnVer
                 , ghjNeeds           = []
                 , ghjSteps           = steps
                 , ghjIf              = Nothing
@@ -765,7 +765,7 @@ postgresService = GitHubService
 ircJob :: String -> String -> String -> Config -> GitConfig -> ListBuilder (String, GitHubJob) ()
 ircJob actionName mainJobName projectName cfg gitconfig = item ("irc", GitHubJob
     { ghjName            = actionName ++ " (IRC notification)"
-    , ghjRunsOn          = "ubuntu-18.04"
+    , ghjRunsOn          = ghcRunsOnVer
     , ghjNeeds           = [mainJobName]
     , ghjIf              = jobCondition
     , ghjContainer       = Nothing
@@ -872,3 +872,10 @@ parseGitHubRepo t =
         repo <- Atto.takeWhile (/= '.')
         _ <- optional (Atto.string ".git")
         return repo
+
+-- NB: The Ubuntu version used in `runs-on` isn't particularly important since
+-- we use a Docker container. We do make an attempt to keep it relatively up to
+-- date to ensure that it runs on a version of Ubuntu that GitHub Actions
+-- runners support.
+ghcRunsOnVer :: String
+ghcRunsOnVer = "ubuntu-20.04"


### PR DESCRIPTION
In the process, update the IRC Ubuntu version to 20.04.

Fixes #608.