### PR TITLE
Adding ability to specify mulitple postgresql versions to be used in builds

### DIFF
--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -81,6 +81,7 @@ data Config = Config
     , cfgFolds               :: S.Set Fold
     , cfgGhcHead             :: !Bool
     , cfgPostgres            :: !Bool
+    , cfgPostgresVersions    :: [String]
     , cfgGoogleChrome        :: !Bool
     , cfgEnv                 :: M.Map Version String
     , cfgAllowFailures       :: !VersionRange
@@ -211,6 +212,8 @@ configGrammar = Config
         ^^^ help "Add ghc-head job"
     <*> C.booleanFieldDef     "postgresql"                                                    (field @"cfgPostgres") False
         ^^^ help "Add postgresql service"
+    <*> C.monoidalFieldAla    "postgresql-versions"        (C.alaList' C.FSep C.Token')        (field @"cfgPostgresVersions")
+        ^^^ help "Postgresql versions to use"
     <*> C.booleanFieldDef     "google-chrome"                                                 (field @"cfgGoogleChrome") False
         ^^^ help "Add google-chrome service"
     <*> C.monoidalFieldAla    "env"                       Env                                 (field @"cfgEnv")

--- a/src/HaskellCI/GitHub/Yaml.hs
+++ b/src/HaskellCI/GitHub/Yaml.hs
@@ -49,6 +49,7 @@ data GitHubMatrixEntry = GitHubMatrixEntry
     { ghmeCompiler     :: CompilerVersion
     , ghmeAllowFailure :: Bool
     , ghmeSetupMethod  :: SetupMethod
+    , ghmePostgresVersion :: String
     }
   deriving (Show)
 
@@ -140,7 +141,7 @@ instance ToYaml GitHubMatrixEntry where
         , "compilerVersion" ~> fromString (compilerVersion ghmeCompiler)
         , "setup-method"    ~> toYaml ghmeSetupMethod
         , "allow-failure"   ~> toYaml ghmeAllowFailure
-        ]
+        , "postgres-version"~> fromString ghmePostgresVersion]
 
 instance ToYaml GitHubStep where
     toYaml GitHubStep {..} = ykeyValuesFilt [] $


### PR DESCRIPTION
this adds a new parameter `postgresql-versions` that one can use to specify more than one postgresql version that is later used in matrix.