### PR TITLE
Allow tree-diff 0.3

### DIFF
--- a/cabal-install-parsers/cabal-install-parsers.cabal
+++ b/cabal-install-parsers/cabal-install-parsers.cabal
@@ -124,7 +124,7 @@ test-suite cabal-parsers-golden
     , ansi-terminal  >=0.10    && <0.12
     , tasty          ^>=1.4
     , tasty-golden   ^>=2.3.1.1
-    , tree-diff      ^>=0.2
+    , tree-diff      >=0.2     && <0.4
 
 benchmark cabal-parsers-bench
   default-language: Haskell2010


### PR DESCRIPTION
Builds fine and all tests pass. The breaking change doesn't seem to affect us.