### PR TITLE
Bump major version of doctest to 0.21

### DIFF
--- a/src/HaskellCI/Config/Doctest.hs
+++ b/src/HaskellCI/Config/Doctest.hs
@@ -26,7 +26,7 @@ data DoctestConfig = DoctestConfig
 -------------------------------------------------------------------------------
 
 defaultDoctestVersion :: VersionRange
-defaultDoctestVersion = majorBoundVersion (mkVersion [0,20,0])
+defaultDoctestVersion = majorBoundVersion (mkVersion [0,21,0])
 
 -------------------------------------------------------------------------------
 -- Grammar


### PR DESCRIPTION
Major change for doctest is support of new cmdline options and support for ghc-9.6 so is safe to bump to new major.