### PR TITLE
Add `apt` field to template `cabal.haskell-ci`

### DIFF
--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -5,6 +5,9 @@
 -- Bionic is a default.
 distribution: jammy
 
+-- list of extra apt packages to be installed
+-- apt: foo bar
+
 jobs: 2:2
 
 -- This is useful if you want limit jobs beyond tested-with specification,


### PR DESCRIPTION
The `apt` flag is accepted on the command line and in the `cabal.haskell-ci` config file, but it is not documented anywhere making it difficult to discover.