### PR TITLE
Decouple head.hackage from job failure and GHC-head/alpha/rc status

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -79,6 +79,7 @@ jobs:
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:

--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -37,7 +37,7 @@ jobs:
             compilerKind: ghc
             compilerVersion: 9.8.0.20230929
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.6.3
             compilerKind: ghc
             compilerVersion: 9.6.3

--- a/fixtures/all-versions.travis
+++ b/fixtures/all-versions.travis
@@ -225,8 +225,6 @@ jobs:
     - compiler: ghc-7.0.1
       addons: {"apt":{"packages":["ghc-7.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu bionic main"}]}}
       os: linux
-  allow_failures:
-    - compiler: ghc-9.8.1
 before_install:
   - |
     if echo $CC | grep -q ghcjs; then

--- a/fixtures/copy-fields-all.github
+++ b/fixtures/copy-fields-all.github
@@ -193,6 +193,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -202,6 +203,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:

--- a/fixtures/copy-fields-none.github
+++ b/fixtures/copy-fields-none.github
@@ -193,6 +193,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -202,6 +203,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:

--- a/fixtures/copy-fields-some.github
+++ b/fixtures/copy-fields-some.github
@@ -193,6 +193,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -202,6 +203,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:

--- a/fixtures/enabled-jobs.github
+++ b/fixtures/enabled-jobs.github
@@ -37,7 +37,7 @@ jobs:
             compilerKind: ghc
             compilerVersion: 9.8.0.20230929
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.6.3
             compilerKind: ghc
             compilerVersion: 9.6.3

--- a/fixtures/enabled-jobs.travis
+++ b/fixtures/enabled-jobs.travis
@@ -171,8 +171,6 @@ jobs:
     - compiler: ghc-8.0.1
       addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu bionic main"}]}}
       os: linux
-  allow_failures:
-    - compiler: ghc-9.8.1
 before_install:
   - |
     if echo $CC | grep -q ghcjs; then

--- a/fixtures/irc-channels.github
+++ b/fixtures/irc-channels.github
@@ -220,6 +220,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -229,6 +230,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:

--- a/fixtures/psql.github
+++ b/fixtures/psql.github
@@ -199,6 +199,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -208,6 +209,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:

--- a/fixtures/travis-patch.github
+++ b/fixtures/travis-patch.github
@@ -193,6 +193,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -202,6 +203,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.17.20230929
+version:            0.17.20231004
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for

--- a/src/HaskellCI.hs
+++ b/src/HaskellCI.hs
@@ -60,7 +60,6 @@ import HaskellCI.Config.Dump
 import HaskellCI.Diagnostics
 import HaskellCI.GitConfig
 import HaskellCI.GitHub
-import HaskellCI.HeadHackage
 import HaskellCI.Jobs
 import HaskellCI.Package
 import HaskellCI.TestedWith
@@ -550,7 +549,7 @@ configFromCabalFile cfg (cabalFile, gpd) = do
     lastStableGhcVers
         = nubBy ((==) `on` ghcMajVer)
         $ sortBy (flip compare)
-        $ filter (not . previewGHC defaultHeadHackage . GHC)
+        $ filter (not . isPreviewGHC . GHC)
         $ knownGhcVersions
 
     isTwoDigitGhcVersion :: VersionRange -> Maybe Version

--- a/src/HaskellCI/Auxiliary.hs
+++ b/src/HaskellCI/Auxiliary.hs
@@ -47,6 +47,7 @@ data Auxiliary = Auxiliary
     , extraCabalProjectFields :: FilePath -> [C.PrettyField ()]
     , testShowDetails         :: String
     , anyJobUsesHeadHackage   :: Bool
+    , anyJobUsesPreviewGHC    :: Bool
     , runHaddock              :: Bool
     , haddockFlags            :: String
     }
@@ -134,10 +135,13 @@ auxiliary Config {..} prj JobVersions {..} = Auxiliary {..}
 
     -- GHC versions which need head.hackage
     headGhcVers :: Set CompilerVersion
-    headGhcVers = S.filter (previewGHC cfgHeadHackage) allVersions
+    headGhcVers = S.filter (usesHeadHackage cfgHeadHackage) allVersions
 
     anyJobUsesHeadHackage :: Bool
-    anyJobUsesHeadHackage = not $ null $ allVersions `S.intersection` headGhcVers
+    anyJobUsesHeadHackage = not $ null headGhcVers
+
+    anyJobUsesPreviewGHC :: Bool
+    anyJobUsesPreviewGHC = not $ null $ S.filter isPreviewGHC allVersions
 
 pkgNameDirVariable' :: String -> String
 pkgNameDirVariable' n = "PKGDIR_" ++ map f n where

--- a/src/HaskellCI/Compiler.hs
+++ b/src/HaskellCI/Compiler.hs
@@ -6,7 +6,10 @@ module HaskellCI.Compiler (
     maybeGHC,
     isGHCJS,
     maybeGHCJS,
-    previewGHC,
+    -- ** Predicates
+    isGHCHead,
+    usesHeadHackage,
+    isPreviewGHC,
     -- ** Selectors
     compilerKind,
     compilerVersion,
@@ -188,14 +191,23 @@ dispCabalVersion = maybe "head" C.prettyShow
 ghcAlpha :: Maybe (Version, Version)
 ghcAlpha = Just (mkVersion [9,8,1], mkVersion [9,8,0,20230929])
 
--- | Alphas, RCs and HEAD.
-previewGHC
+-- | GHC HEAD, and versions specified by head.hackage option.
+usesHeadHackage
     :: VersionRange     -- ^ head.hackage range
     -> CompilerVersion
     -> Bool
-previewGHC _vr GHCHead   = True
-previewGHC  vr (GHC v)   = withinRange v vr || odd (snd (ghcMajVer v)) || maybe False (\(v', _) -> v >= v') ghcAlpha
-previewGHC _vr (GHCJS _) = False
+usesHeadHackage _vr GHCHead   = True
+usesHeadHackage  vr (GHC v)   = withinRange v vr
+usesHeadHackage _vr (GHCJS _) = False
+
+isPreviewGHC :: CompilerVersion -> Bool
+isPreviewGHC GHCHead   = True
+isPreviewGHC (GHC v)   = maybe False (\(v', _) -> v /= v') ghcAlpha
+isPreviewGHC (GHCJS _) = False
+
+isGHCHead :: CompilerVersion -> Bool
+isGHCHead GHCHead = True
+isGHCHead _       = False
 
 previewCabal
     :: Maybe Version

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -155,7 +155,7 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
                     sh $ "chmod a+x \"$HOME/.ghcup/bin/ghcup\""
 
                     -- if any job uses prereleases, add release channel unconditionally. (HEADHACKAGE variable is set later)
-                    when (anyJobUsesHeadHackage || previewCabal cfgCabalInstallVersion) $
+                    when (anyJobUsesPreviewGHC || previewCabal cfgCabalInstallVersion) $
                       sh "\"$HOME/.ghcup/bin/ghcup\" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;"
 
                 installGhcupCabal :: ShM ()
@@ -638,7 +638,7 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
                     [ GitHubMatrixEntry
                         { ghmeCompiler     = translateCompilerVersion $ compiler
                         , ghmeAllowFailure =
-                               previewGHC cfgHeadHackage compiler
+                               isGHCHead compiler
                             || maybeGHC False (`C.withinRange` cfgAllowFailures) compiler
                         , ghmeSetupMethod = if isGHCUP compiler then GHCUP else HVRPPA
                         }

--- a/src/HaskellCI/Travis.hs
+++ b/src/HaskellCI/Travis.hs
@@ -505,7 +505,7 @@ makeTravis argv config@Config {..} prj jobs@JobVersions {..} = do
             , tmAllowFailures =
                 [ TravisAllowFailure $ dispGhcVersion compiler
                 | compiler <- toList allVersions
-                , previewGHC cfgHeadHackage compiler || maybeGHC False (`C.withinRange` cfgAllowFailures) compiler
+                , isGHCHead compiler || maybeGHC False (`C.withinRange` cfgAllowFailures) compiler
                 ]
             }
         , travisBeforeCache   = beforeCache
@@ -550,7 +550,7 @@ makeTravis argv config@Config {..} prj jobs@JobVersions {..} = do
 
     -- GHC versions which need head.hackage
     headGhcVers :: Set CompilerVersion
-    headGhcVers = S.filter (previewGHC cfgHeadHackage) allVersions
+    headGhcVers = S.filter (usesHeadHackage cfgHeadHackage) allVersions
 
     cabal :: String -> String
     cabal cmd = "${CABAL} " ++ cmd


### PR DESCRIPTION
Now you can disable `head.hackage` for GHC-alpha/previews and it won't show in the config. For example https://github.com/haskell-hvr/text-short/pull/42