### PR TITLE
GitHub: use `ghcup` as default (rather than `hvr-ppa`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HC ?= ghc-9.2.7
+HC ?= ghc-9.4.7
 
 build :
 	cabal v2-build -w $(HC)

--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -136,7 +136,7 @@ jobs:
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -156,82 +156,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -241,7 +241,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -251,7 +251,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -366,7 +366,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/copy-fields-all.github
+++ b/fixtures/copy-fields-all.github
@@ -46,82 +46,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -131,7 +131,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -141,7 +141,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -188,7 +188,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/copy-fields-none.github
+++ b/fixtures/copy-fields-none.github
@@ -46,82 +46,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -131,7 +131,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -141,7 +141,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -188,7 +188,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/copy-fields-some.github
+++ b/fixtures/copy-fields-some.github
@@ -46,82 +46,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -131,7 +131,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -141,7 +141,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -188,7 +188,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/empty-line.github
+++ b/fixtures/empty-line.github
@@ -46,82 +46,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -131,7 +131,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -141,7 +141,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -188,7 +188,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/enabled-jobs.github
+++ b/fixtures/enabled-jobs.github
@@ -136,7 +136,7 @@ jobs:
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -156,82 +156,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -241,7 +241,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -251,7 +251,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -276,7 +276,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/irc-channels.github
+++ b/fixtures/irc-channels.github
@@ -73,82 +73,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -158,7 +158,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -168,7 +168,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -215,7 +215,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/messy.github
+++ b/fixtures/messy.github
@@ -46,82 +46,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -131,7 +131,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -141,7 +141,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -188,7 +188,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/psql.github
+++ b/fixtures/psql.github
@@ -52,82 +52,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -137,7 +137,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -147,7 +147,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -194,7 +194,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/fixtures/travis-patch.github
+++ b/fixtures/travis-patch.github
@@ -46,82 +46,82 @@ jobs:
           - compiler: ghc-8.10.4
             compilerKind: ghc
             compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.3
             compilerKind: ghc
             compilerVersion: 8.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.2
             compilerKind: ghc
             compilerVersion: 8.10.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.1
             compilerKind: ghc
             compilerVersion: 8.10.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.2
             compilerKind: ghc
             compilerVersion: 8.8.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.1
             compilerKind: ghc
             compilerVersion: 8.8.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.4
             compilerKind: ghc
             compilerVersion: 8.6.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.3
             compilerKind: ghc
             compilerVersion: 8.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.2
             compilerKind: ghc
             compilerVersion: 8.6.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.1
             compilerKind: ghc
             compilerVersion: 8.6.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.3
             compilerKind: ghc
             compilerVersion: 8.4.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.2
             compilerKind: ghc
             compilerVersion: 8.4.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.1
             compilerKind: ghc
@@ -131,7 +131,7 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.1
             compilerKind: ghc
@@ -141,7 +141,7 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.1
             compilerKind: ghc
@@ -188,7 +188,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"

--- a/src/HaskellCI/Config.hs
+++ b/src/HaskellCI/Config.hs
@@ -220,7 +220,7 @@ configGrammar = Config
         ^^^ metahelp "RANGE" "Jobs to additionally build with OSX"
     <*> C.booleanFieldDef     "ghcup-cabal"                                                   (field @"cfgGhcupCabal") True
         ^^^ help "Use (or don't) ghcup to install cabal"
-    <*> rangeField            "ghcup-jobs"                                                    (field @"cfgGhcupJobs") (C.unionVersionRanges (C.intersectVersionRanges (C.laterVersion (mkVersion [8,10,4])) (C.earlierVersion (mkVersion [9]))) (C.laterVersion (mkVersion [9,0,1])))
+    <*> rangeField            "ghcup-jobs"                                                    (field @"cfgGhcupJobs") ghcupVersions
         ^^^ metahelp "RANGE" "(Linux) jobs to use ghcup to install tools"
     <*> C.optionalFieldDef    "ghcup-version"                                                 (field @"cfgGhcupVersion") defaultGhcupVersion
         ^^^ metahelp "VERSION" "ghcup version"
@@ -245,6 +245,17 @@ configGrammar = Config
         ^^^ help "The name of GitHub Action"
     <*> C.optionalFieldDef    "timeout-minutes"                                              (field @"cfgTimeoutMinutes") 60
         ^^^ metahelp "MINUTES" "The maximum number of minutes to let a job run"
+  where
+    -- Versions supported by GHCup.
+    -- As of 2023-10-12, GHCup supports all minor versions of GHC 8.4 and up
+    -- and the latest minor versions of 8.2, 8.0, and 7.10.
+    -- However, GH 7.10.3 has problems when installed with GHCup, so we don't include it here.
+    ghcupVersions :: C.VersionRange
+    ghcupVersions = foldr1 C.unionVersionRanges
+      [ C.laterVersion $ mkVersion [8,4,1]
+      , C.thisVersion  $ mkVersion [8,2,2]
+      , C.thisVersion  $ mkVersion [8,0,2]
+      ]
 
 -------------------------------------------------------------------------------
 -- Reading


### PR DESCRIPTION
Motivation: recently, I am getting many failures of CI due to failure of installing GHC from `hvr-ppa`. 
E.g.: https://github.com/MarcWeber/hasktags/actions/runs/6487255991/job/17617157111#step:3:420
```
Failed to open connection to "system" message bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
Created symlink /etc/systemd/user/sockets.target.wants/pk-debconf-helper.socket → /usr/lib/systemd/user/pk-debconf-helper.socket.
Setting up software-properties-common (0.99.9.12) ...
Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
Processing triggers for dbus (1.12.16-2ubuntu2.3) ...
Cannot add PPA: 'ppa:~hvr/ubuntu/ghc'.
The user named '~hvr' has no PPA named 'ubuntu/ghc'
```
Also, the `hvr-ppa` is no longer maintained and it does not look like it will come back.

This PR changes the default installation method from `hvr-ppa` to `ghcup` for the versions supported by `ghcup`.

Commits:
- Bump GHC building haskell-ci to latest recommended: 9.4.7
- GitHub: change default from `hvr-ppa` to `ghcup`
