### PR TITLE
By default, do not constrain `doctest`

### DIFF
--- a/src/HaskellCI/Config/Doctest.hs
+++ b/src/HaskellCI/Config/Doctest.hs
@@ -5,8 +5,6 @@ module HaskellCI.Config.Doctest where
 
 import HaskellCI.Prelude
 
-import Distribution.Version (majorBoundVersion)
-
 import qualified Distribution.FieldGrammar      as C
 import qualified Distribution.Types.PackageName as C
 
@@ -26,7 +24,7 @@ data DoctestConfig = DoctestConfig
 -------------------------------------------------------------------------------
 
 defaultDoctestVersion :: VersionRange
-defaultDoctestVersion = majorBoundVersion (mkVersion [0,21,0])
+defaultDoctestVersion = anyVersion
 
 -------------------------------------------------------------------------------
 -- Grammar


### PR DESCRIPTION
`doctest` bound has been rotting too quickly.
Just use the latest version by default.
Can always be overwritting by `doctest-version` option in `cabal.haskell-ci`.

Closes https://github.com/haskell-CI/haskell-ci/issues/690
