### PR TITLE
Add regenerate hook for pre-commit.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   name: haskell-ci regenerate
   entry: haskell-ci regenerate
   language: haskell
-  files: '.*\.cabal'
+  files: '(\.cabal$)|(^.github/workflows/haskell-ci.yml$)|(.travis.yml$)'
   pass_filenames: false
   description: |-
     Regenerate Haskell CI configurations with haskell-ci.  Configuration must

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,11 @@
+- id: regenerate
+  name: haskell-ci regenerate
+  entry: haskell-ci regenerate
+  language: haskell
+  files: '.*\.cabal'
+  pass_filenames: false
+  description: |-
+    Regenerate Haskell CI configurations with haskell-ci.  Configuration must
+    already exist.
+  minimum_pre_commit_version: '3.4.0'
+  


### PR DESCRIPTION
This allows pre-commit to use haskell-ci to regenerate configuration as part of the pre-commit hook or CI with minimal setup per environment.

Tested with `pre-commit try-repo --all-files .`

Let me know if any documentation would be helpful to include with this setup or if there is a preference for a different configuration.  pre-commit isn't often used in the Haskell community but I've been using it to keep environments consistent for some time and would like it to have more Haskell tooling.