### PR TITLE
Make GHCUP the only installation method for cabal-install

### DIFF
--- a/fixtures/all-versions.travis
+++ b/fixtures/all-versions.travis
@@ -37,154 +37,154 @@ jobs:
       addons: {"apt":{"packages":["ghcjs-8.4","cabal-install-3.4","ghc-8.4.4","nodejs"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"},{"sourceline":"deb http://ppa.launchpad.net/hvr/ghcjs/ubuntu jammy main"},{"key_url":"https://deb.nodesource.com/gpgkey/nodesource.gpg.key","sourceline":"deb https://deb.nodesource.com/node_10.x jammy main"}]}}
       os: linux
     - compiler: ghc-9.10.1
-      addons: {"apt":{"packages":["ghc-9.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.8.2
-      addons: {"apt":{"packages":["ghc-9.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.8.1
-      addons: {"apt":{"packages":["ghc-9.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.5
-      addons: {"apt":{"packages":["ghc-9.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.4
-      addons: {"apt":{"packages":["ghc-9.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.3
-      addons: {"apt":{"packages":["ghc-9.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.2
-      addons: {"apt":{"packages":["ghc-9.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.1
-      addons: {"apt":{"packages":["ghc-9.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.8
-      addons: {"apt":{"packages":["ghc-9.4.8","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.8","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.7
-      addons: {"apt":{"packages":["ghc-9.4.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.6
-      addons: {"apt":{"packages":["ghc-9.4.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.5
-      addons: {"apt":{"packages":["ghc-9.4.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.4
-      addons: {"apt":{"packages":["ghc-9.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.3
-      addons: {"apt":{"packages":["ghc-9.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.2
-      addons: {"apt":{"packages":["ghc-9.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.1
-      addons: {"apt":{"packages":["ghc-9.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.8
-      addons: {"apt":{"packages":["ghc-9.2.8","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.8","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.7
-      addons: {"apt":{"packages":["ghc-9.2.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.6
-      addons: {"apt":{"packages":["ghc-9.2.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.5
-      addons: {"apt":{"packages":["ghc-9.2.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.4
-      addons: {"apt":{"packages":["ghc-9.2.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.3
-      addons: {"apt":{"packages":["ghc-9.2.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.2
-      addons: {"apt":{"packages":["ghc-9.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.1
-      addons: {"apt":{"packages":["ghc-9.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.0.2
-      addons: {"apt":{"packages":["ghc-9.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.0.1
-      addons: {"apt":{"packages":["ghc-9.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - |

--- a/fixtures/copy-fields-all.travis
+++ b/fixtures/copy-fields-all.travis
@@ -34,76 +34,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')

--- a/fixtures/copy-fields-none.travis
+++ b/fixtures/copy-fields-none.travis
@@ -34,76 +34,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')

--- a/fixtures/copy-fields-some.travis
+++ b/fixtures/copy-fields-some.travis
@@ -34,76 +34,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')

--- a/fixtures/doctest-version.travis
+++ b/fixtures/doctest-version.travis
@@ -37,154 +37,154 @@ jobs:
       addons: {"apt":{"packages":["ghcjs-8.4","cabal-install-3.4","ghc-8.4.4","nodejs"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"},{"sourceline":"deb http://ppa.launchpad.net/hvr/ghcjs/ubuntu jammy main"},{"key_url":"https://deb.nodesource.com/gpgkey/nodesource.gpg.key","sourceline":"deb https://deb.nodesource.com/node_10.x jammy main"}]}}
       os: linux
     - compiler: ghc-9.10.1
-      addons: {"apt":{"packages":["ghc-9.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.8.2
-      addons: {"apt":{"packages":["ghc-9.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.8.1
-      addons: {"apt":{"packages":["ghc-9.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.5
-      addons: {"apt":{"packages":["ghc-9.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.4
-      addons: {"apt":{"packages":["ghc-9.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.3
-      addons: {"apt":{"packages":["ghc-9.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.2
-      addons: {"apt":{"packages":["ghc-9.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.1
-      addons: {"apt":{"packages":["ghc-9.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.8
-      addons: {"apt":{"packages":["ghc-9.4.8","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.8","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.7
-      addons: {"apt":{"packages":["ghc-9.4.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.6
-      addons: {"apt":{"packages":["ghc-9.4.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.5
-      addons: {"apt":{"packages":["ghc-9.4.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.4
-      addons: {"apt":{"packages":["ghc-9.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.3
-      addons: {"apt":{"packages":["ghc-9.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.2
-      addons: {"apt":{"packages":["ghc-9.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.1
-      addons: {"apt":{"packages":["ghc-9.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.8
-      addons: {"apt":{"packages":["ghc-9.2.8","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.8","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.7
-      addons: {"apt":{"packages":["ghc-9.2.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.6
-      addons: {"apt":{"packages":["ghc-9.2.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.5
-      addons: {"apt":{"packages":["ghc-9.2.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.4
-      addons: {"apt":{"packages":["ghc-9.2.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.3
-      addons: {"apt":{"packages":["ghc-9.2.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.2
-      addons: {"apt":{"packages":["ghc-9.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.1
-      addons: {"apt":{"packages":["ghc-9.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.0.2
-      addons: {"apt":{"packages":["ghc-9.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.0.1
-      addons: {"apt":{"packages":["ghc-9.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - |

--- a/fixtures/doctest.travis
+++ b/fixtures/doctest.travis
@@ -37,154 +37,154 @@ jobs:
       addons: {"apt":{"packages":["ghcjs-8.4","cabal-install-3.4","ghc-8.4.4","nodejs"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"},{"sourceline":"deb http://ppa.launchpad.net/hvr/ghcjs/ubuntu jammy main"},{"key_url":"https://deb.nodesource.com/gpgkey/nodesource.gpg.key","sourceline":"deb https://deb.nodesource.com/node_10.x jammy main"}]}}
       os: linux
     - compiler: ghc-9.10.1
-      addons: {"apt":{"packages":["ghc-9.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.8.2
-      addons: {"apt":{"packages":["ghc-9.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.8.1
-      addons: {"apt":{"packages":["ghc-9.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.5
-      addons: {"apt":{"packages":["ghc-9.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.4
-      addons: {"apt":{"packages":["ghc-9.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.3
-      addons: {"apt":{"packages":["ghc-9.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.2
-      addons: {"apt":{"packages":["ghc-9.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.1
-      addons: {"apt":{"packages":["ghc-9.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.8
-      addons: {"apt":{"packages":["ghc-9.4.8","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.8","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.7
-      addons: {"apt":{"packages":["ghc-9.4.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.6
-      addons: {"apt":{"packages":["ghc-9.4.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.5
-      addons: {"apt":{"packages":["ghc-9.4.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.4
-      addons: {"apt":{"packages":["ghc-9.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.3
-      addons: {"apt":{"packages":["ghc-9.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.2
-      addons: {"apt":{"packages":["ghc-9.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.1
-      addons: {"apt":{"packages":["ghc-9.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.8
-      addons: {"apt":{"packages":["ghc-9.2.8","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.8","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.7
-      addons: {"apt":{"packages":["ghc-9.2.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.6
-      addons: {"apt":{"packages":["ghc-9.2.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.5
-      addons: {"apt":{"packages":["ghc-9.2.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.4
-      addons: {"apt":{"packages":["ghc-9.2.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.3
-      addons: {"apt":{"packages":["ghc-9.2.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.2
-      addons: {"apt":{"packages":["ghc-9.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.1
-      addons: {"apt":{"packages":["ghc-9.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.0.2
-      addons: {"apt":{"packages":["ghc-9.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.0.1
-      addons: {"apt":{"packages":["ghc-9.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - |

--- a/fixtures/empty-line.travis
+++ b/fixtures/empty-line.travis
@@ -34,76 +34,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-head
       addons: {"apt":{"packages":["ghc-head","cabal-install-head"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}

--- a/fixtures/enabled-jobs.travis
+++ b/fixtures/enabled-jobs.travis
@@ -37,154 +37,154 @@ jobs:
       addons: {"apt":{"packages":["ghcjs-8.4","cabal-install-3.4","ghc-8.4.4","nodejs"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"},{"sourceline":"deb http://ppa.launchpad.net/hvr/ghcjs/ubuntu jammy main"},{"key_url":"https://deb.nodesource.com/gpgkey/nodesource.gpg.key","sourceline":"deb https://deb.nodesource.com/node_10.x jammy main"}]}}
       os: linux
     - compiler: ghc-9.10.1
-      addons: {"apt":{"packages":["ghc-9.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.8.2
-      addons: {"apt":{"packages":["ghc-9.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.8.1
-      addons: {"apt":{"packages":["ghc-9.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.5
-      addons: {"apt":{"packages":["ghc-9.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.4
-      addons: {"apt":{"packages":["ghc-9.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.3
-      addons: {"apt":{"packages":["ghc-9.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.2
-      addons: {"apt":{"packages":["ghc-9.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.6.1
-      addons: {"apt":{"packages":["ghc-9.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.8
-      addons: {"apt":{"packages":["ghc-9.4.8","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.8","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.7
-      addons: {"apt":{"packages":["ghc-9.4.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.6
-      addons: {"apt":{"packages":["ghc-9.4.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.5
-      addons: {"apt":{"packages":["ghc-9.4.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.4
-      addons: {"apt":{"packages":["ghc-9.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.3
-      addons: {"apt":{"packages":["ghc-9.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.2
-      addons: {"apt":{"packages":["ghc-9.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.4.1
-      addons: {"apt":{"packages":["ghc-9.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.8
-      addons: {"apt":{"packages":["ghc-9.2.8","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.8","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.7
-      addons: {"apt":{"packages":["ghc-9.2.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.6
-      addons: {"apt":{"packages":["ghc-9.2.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.5
-      addons: {"apt":{"packages":["ghc-9.2.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.4
-      addons: {"apt":{"packages":["ghc-9.2.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.3
-      addons: {"apt":{"packages":["ghc-9.2.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.2
-      addons: {"apt":{"packages":["ghc-9.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.2.1
-      addons: {"apt":{"packages":["ghc-9.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.0.2
-      addons: {"apt":{"packages":["ghc-9.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-9.0.1
-      addons: {"apt":{"packages":["ghc-9.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-9.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - |

--- a/fixtures/fail-versions.travis
+++ b/fixtures/fail-versions.travis
@@ -34,76 +34,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')

--- a/fixtures/irc-channels.travis
+++ b/fixtures/irc-channels.travis
@@ -41,76 +41,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')

--- a/fixtures/messy.travis
+++ b/fixtures/messy.travis
@@ -34,76 +34,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-head
       addons: {"apt":{"packages":["ghc-head","cabal-install-head","fftw3-dev"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}

--- a/fixtures/psql.travis
+++ b/fixtures/psql.travis
@@ -38,76 +38,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')

--- a/fixtures/travis-patch.travis
+++ b/fixtures/travis-patch.travis
@@ -34,76 +34,76 @@ before_cache:
 jobs:
   include:
     - compiler: ghc-8.10.7
-      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.7","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.6
-      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.6","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.5
-      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.4
-      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.3
-      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.2
-      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.10.1
-      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.10.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.4
-      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.3
-      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.2
-      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.8.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.5","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.4
-      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.3
-      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.2
-      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.6.1
-      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.6.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.4","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.3
-      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.3","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.2
-      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.4.1
-      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.4.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.2.1
-      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.2.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.2","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
     - compiler: ghc-8.0.1
-      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
+      addons: {"apt":{"packages":["ghc-8.0.1","cabal-install-3.10.2.0"],"sources":[{"key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286","sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu jammy main"}]}}
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.19.20240608
+version:            0.19.20240701
 synopsis:           Cabal package script generator for Travis-CI
 description:
   Script generator (@haskell-ci@) for

--- a/src/HaskellCI/Cabal.hs
+++ b/src/HaskellCI/Cabal.hs
@@ -1,14 +1,1 @@
 module HaskellCI.Cabal where
-
-import HaskellCI.Prelude
-
-import qualified Distribution.Version as C
-
--- | Convert cabal-install version to a version ghcup understands.
-cabalGhcupVersion :: Version -> Version
-cabalGhcupVersion ver = case C.versionNumbers ver of
-      [3,10] -> C.mkVersion [3,10,2,0]
-      [3,9]  -> C.mkVersion [3,9,0,0]
-      [3,6]  -> C.mkVersion [3,6,2,0]
-      [x,y]  -> C.mkVersion [x,y,0,0]
-      _      -> ver

--- a/src/HaskellCI/Config/Initial.hs
+++ b/src/HaskellCI/Config/Initial.hs
@@ -21,7 +21,7 @@ import HaskellCI.TestedWith
 -- All changes to defaults should be done in History.
 initialConfig :: Config
 initialConfig = Config
-    { cfgCabalInstallVersion = Just (C.mkVersion [3,10])
+    { cfgCabalInstallVersion = Just (C.mkVersion [3,10,2,0])
     , cfgJobs                = Nothing
     , cfgUbuntu              = Bionic
     , cfgTestedWith          = TestedWithUniform

--- a/src/HaskellCI/Config/Validity.hs
+++ b/src/HaskellCI/Config/Validity.hs
@@ -15,3 +15,6 @@ checkConfigValidity :: MonadErr HsCiError m => Config -> JobVersions -> m ()
 checkConfigValidity Config {..} _  = do
     unless (cfgUbuntu >= Focal) $
         throwErr $ ValidationError $ prettyShow cfgUbuntu ++ "distribution is not supported"
+
+    unless cfgGhcupCabal $
+        throwErr $ ValidationError $ "The GHCUP is the only supported installation method for cabal-install"

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -30,7 +30,6 @@ import qualified Distribution.Version            as C
 
 import Cabal.Project
 import HaskellCI.Auxiliary
-import HaskellCI.Cabal
 import HaskellCI.Compiler
 import HaskellCI.Config
 import HaskellCI.Config.ConstraintSet
@@ -170,16 +169,16 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
                     sh_if RangeGHCJS "curl -sSL \"https://deb.nodesource.com/gpgkey/nodesource.gpg.key\" | apt-key add -"
                     sh_if RangeGHCJS $ "apt-add-repository -y 'deb https://deb.nodesource.com/node_10.x " ++ ubuntuVer ++ " main'"
                 sh "apt-get update"
-                let basePackages  = ["\"$HCNAME\"" ] ++ [ "cabal-install-" ++ cabalVer | not cfgGhcupCabal ] ++ S.toList cfgApt
+                let basePackages  = ["\"$HCNAME\"" ] ++ S.toList cfgApt
                     ghcjsPackages = ["ghc-8.4.4", "nodejs"]
                     baseInstall   = "apt-get install -y " ++ unwords basePackages
                     ghcjsInstall  = "apt-get install -y " ++ unwords (basePackages ++ ghcjsPackages)
                 if anyGHCJS
                     then if_then_else RangeGHCJS ghcjsInstall baseInstall
                     else sh baseInstall
-                when cfgGhcupCabal $ do
-                    installGhcup
-                    installGhcupCabal
+
+                installGhcup
+                installGhcupCabal
 
             ghcup <- runSh $ do
                 installGhcup
@@ -617,7 +616,7 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
 
     ubuntuVer    = showUbuntu cfgUbuntu
     cabalVer     = dispCabalVersion cfgCabalInstallVersion
-    cabalFullVer = dispCabalVersion $ cabalGhcupVersion <$> cfgCabalInstallVersion
+    cabalFullVer = dispCabalVersion cfgCabalInstallVersion
 
     Auxiliary {..} = auxiliary config prj jobs
 


### PR DESCRIPTION
Also remove version mapping, Closes #732