### PR TITLE
Update default ubuntu runner and container version

### DIFF
--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/copy-fields-all.github
+++ b/fixtures/copy-fields-all.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/copy-fields-none.github
+++ b/fixtures/copy-fields-none.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/copy-fields-some.github
+++ b/fixtures/copy-fields-some.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/doctest-version.github
+++ b/fixtures/doctest-version.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/doctest.github
+++ b/fixtures/doctest.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/empty-line.github
+++ b/fixtures/empty-line.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/enabled-jobs.github
+++ b/fixtures/enabled-jobs.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/fail-versions.github
+++ b/fixtures/fail-versions.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/irc-channels.github
+++ b/fixtures/irc-channels.github
@@ -19,7 +19,7 @@ on:
 jobs:
   irc:
     name: Haskell-CI (IRC notification)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - linux
     if: ${{ always() }}
@@ -46,7 +46,7 @@ jobs:
           server: irc.libera.chat
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/messy.github
+++ b/fixtures/messy.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/psql.github
+++ b/fixtures/psql.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/fixtures/travis-patch.github
+++ b/fixtures/travis-patch.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:

--- a/src/HaskellCI/Config/Initial.hs
+++ b/src/HaskellCI/Config/Initial.hs
@@ -23,7 +23,7 @@ initialConfig :: Config
 initialConfig = Config
     { cfgCabalInstallVersion = Just (C.mkVersion [3,10,2,0])
     , cfgJobs                = Nothing
-    , cfgUbuntu              = Bionic
+    , cfgUbuntu              = Jammy
     , cfgTestedWith          = TestedWithUniform
     , cfgEnabledJobs         = anyVersion
     , cfgCopyFields          = CopyFieldsSome

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -854,4 +854,4 @@ parseGitHubRepo t =
 -- date to ensure that it runs on a version of Ubuntu that GitHub Actions
 -- runners support.
 ghcRunsOnVer :: String
-ghcRunsOnVer = "ubuntu-20.04"
+ghcRunsOnVer = "ubuntu-22.04"


### PR DESCRIPTION
Update to a more recent ubuntu runner, and update the default container to one that works with latest versions of the checkout action.

Closes #738 