### PR TITLE
Correct version number for GHC 9.12.1-alpha1

### DIFF
--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -33,9 +33,9 @@ jobs:
             compilerVersion: "8.4"
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-9.12.0.20241014
+          - compiler: ghc-9.12.20241014
             compilerKind: ghc
-            compilerVersion: 9.12.0.20241014
+            compilerVersion: 9.12.20241014
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1

--- a/fixtures/doctest-version.github
+++ b/fixtures/doctest-version.github
@@ -33,9 +33,9 @@ jobs:
             compilerVersion: "8.4"
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-9.12.0.20241014
+          - compiler: ghc-9.12.20241014
             compilerKind: ghc
-            compilerVersion: 9.12.0.20241014
+            compilerVersion: 9.12.20241014
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1

--- a/fixtures/doctest.github
+++ b/fixtures/doctest.github
@@ -33,9 +33,9 @@ jobs:
             compilerVersion: "8.4"
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-9.12.0.20241014
+          - compiler: ghc-9.12.20241014
             compilerKind: ghc
-            compilerVersion: 9.12.0.20241014
+            compilerVersion: 9.12.20241014
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1

--- a/fixtures/enabled-jobs.github
+++ b/fixtures/enabled-jobs.github
@@ -33,9 +33,9 @@ jobs:
             compilerVersion: "8.4"
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-9.12.0.20241014
+          - compiler: ghc-9.12.20241014
             compilerKind: ghc
-            compilerVersion: 9.12.0.20241014
+            compilerVersion: 9.12.20241014
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1

--- a/src/HaskellCI/Compiler.hs
+++ b/src/HaskellCI/Compiler.hs
@@ -185,7 +185,10 @@ dispCabalVersion :: Maybe Version -> String
 dispCabalVersion = maybe "head" C.prettyShow
 
 ghcAlpha :: Maybe (Version, Version)
-ghcAlpha = Just (mkVersion [9,12,1], mkVersion [9,12,0,20241014])
+-- Due to a packaging mistake, GHC 9.12.1-alpha1 uses the version number
+-- 9.12.20241014 rather than 9.12.0.20241014. See
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/25123#note_591718
+ghcAlpha = Just (mkVersion [9,12,1], mkVersion [9,12,20241014])
 
 -- | GHC HEAD, and versions specified by head.hackage option.
 usesHeadHackage


### PR DESCRIPTION
Due to a packaging mistake, GHC 9.12.1-alpha1 uses the version number 9.12.20241014 rather than 9.12.0.20241014. See
https://gitlab.haskell.org/ghc/ghc/-/issues/25123#note_591718.

This updates `haskell-ci` to use the actual version number.