### PR TITLE
Fix suspected typo in Config/History.hs

### DIFF
--- a/src/HaskellCI/Config/History.hs
+++ b/src/HaskellCI/Config/History.hs
@@ -39,7 +39,7 @@ configHistory =
             , ghcupVanilla    = C.withinVersion (C.mkVersion [9,8,3])
             , ghcupPrerelease = C.orLaterVersion (C.mkVersion [9,12,0])
             }
-    , ver 0 19 2024114 := \cfg -> cfg
+    , ver 0 19 20241114 := \cfg -> cfg
         & field @"cfgSetupMethods" .~ PerSetupMethod
             { hvrPpa          = C.noVersion
             , ghcup           = invertVersionRange (C.withinVersion (C.mkVersion [9,8,3])) /\ C.earlierVersion (C.mkVersion [9,12])


### PR DESCRIPTION
I suppose 2024114 was meant to be 20241114 in the version history.