### PR TITLE
Switch GHA runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HC ?= ghc-9.8.2
+HC ?= ghc-9.8.4
 
 build :
 	cabal v2-build -w $(HC)

--- a/fixtures/all-versions.github
+++ b/fixtures/all-versions.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/copy-fields-all.github
+++ b/fixtures/copy-fields-all.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/copy-fields-none.github
+++ b/fixtures/copy-fields-none.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/copy-fields-some.github
+++ b/fixtures/copy-fields-some.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/doctest-version.github
+++ b/fixtures/doctest-version.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/doctest.github
+++ b/fixtures/doctest.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/empty-line.github
+++ b/fixtures/empty-line.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/enabled-jobs.github
+++ b/fixtures/enabled-jobs.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/fail-versions.github
+++ b/fixtures/fail-versions.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/irc-channels.github
+++ b/fixtures/irc-channels.github
@@ -19,7 +19,7 @@ on:
 jobs:
   irc:
     name: Haskell-CI (IRC notification)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - linux
     if: ${{ always() }}
@@ -46,7 +46,7 @@ jobs:
           server: irc.libera.chat
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/messy.github
+++ b/fixtures/messy.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/psql.github
+++ b/fixtures/psql.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/fixtures/travis-patch.github
+++ b/fixtures/travis-patch.github
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:

--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.19.20250115
+version:            0.19.20250216
 synopsis:           Haskell CI script generator
 description:
   Script generator (@haskell-ci@) for

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -781,7 +781,7 @@ parseGitHubRepo t =
 -- date to ensure that it runs on a version of Ubuntu that GitHub Actions
 -- runners support.
 ghcRunsOnVer :: String
-ghcRunsOnVer = "ubuntu-20.04"
+ghcRunsOnVer = "ubuntu-24.04"
 
 translateCompilerVersion :: Map Version Version -> CompilerVersion -> CompilerVersion
 translateCompilerVersion m (GHC v) = GHC (Map.findWithDefault v v m)


### PR DESCRIPTION
Resolves #769

Note: maybe we could use ubuntu-latest, but OTOH doing an update once in 3-4 years is not a big trouble.