### PR TITLE
v0.19.20250908: Github target: Use actions/checkout v5

### DIFF
--- a/haskell-ci.cabal
+++ b/haskell-ci.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               haskell-ci
-version:            0.19.20250821
+version:            0.19.20250908
 synopsis:           Haskell CI script generator
 description:
   Script generator (@haskell-ci@) for

--- a/src/HaskellCI/GitHub.hs
+++ b/src/HaskellCI/GitHub.hs
@@ -313,7 +313,7 @@ makeGitHub _argv config@Config {..} gitconfig prj jobs@JobVersions {..} = do
             , ("path", "~/.haskell-ci-tools")
             ]
 
-        githubUses "checkout" "actions/checkout@v4" $ buildList $ do
+        githubUses "checkout" "actions/checkout@v5" $ buildList $ do
             item ("path", "source")
             when cfgSubmodules $
                 item ("submodules", "true")


### PR DESCRIPTION
Dependabot complains about `actions/checkout@v4`
