### PR TITLE
Fix typos

### DIFF
--- a/cabal-install-parsers/src/Cabal/Package.hs
+++ b/cabal-install-parsers/src/Cabal/Package.hs
@@ -14,7 +14,7 @@ import qualified Distribution.PackageDescription.Parsec as C
 
 import Cabal.Parse
 
--- | High level convinience function to read package definitons, @.cabal@ files.
+-- | High level convenience function to read package definitions, @.cabal@ files.
 --
 -- May throw 'IOException' when file doesn't exist, and 'ParseError'
 -- on parse error.

--- a/cabal-install-parsers/src/Cabal/Project.hs
+++ b/cabal-install-parsers/src/Cabal/Project.hs
@@ -88,7 +88,7 @@ data Project uri opt pkg = Project
     { prjPackages     :: [pkg]  -- ^ packages field
     , prjOptPackages  :: [opt]  -- ^ optional packages
     , prjUriPackages  :: [uri]  -- ^ URI packages, filled in by 'resolveProject'
-    , prjConstraints  :: [String] -- ^ constaints, parsed as 'String's.
+    , prjConstraints  :: [String] -- ^ constraints, parsed as 'String's.
     , prjAllowNewer   :: [String] -- ^ allow-newer, parsed as 'String's.
     , prjReorderGoals :: Bool
     , prjMaxBackjumps :: Maybe Int

--- a/cabal-install-parsers/test/Index.hs
+++ b/cabal-install-parsers/test/Index.hs
@@ -22,7 +22,7 @@ import Cabal.Index
 main :: IO ()
 main = defaultMain $ testGroup "Cabal.Index"
     [ testGroup "SHA256"
-        [ testCase "Base16.encode . getSHA256 . unsafeMkSHA256 rountrip" $ do
+        [ testCase "Base16.encode . getSHA256 . unsafeMkSHA256 roundtrip" $ do
             let s :: IsString s => s
                 s = "a6f5eddcff9526c786a1b77bdfade54b42f67c066b379bbc4b55ffb291e6c7d6"
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Continous Integration with Haskell
+Continuous Integration with Haskell
 ==================================
 
 Contents:

--- a/fixtures/servant-client/servant-client.cabal
+++ b/fixtures/servant-client/servant-client.cabal
@@ -1,6 +1,6 @@
 name:                servant-client
 version:             0.11
-synopsis: automatical derivation of querying functions for servant webservices
+synopsis: automatically derivation of querying functions for servant webservices
 description:
   This library lets you derive automatically Haskell functions that
   let you query each endpoint of a <http://hackage.haskell.org/package/servant servant> webservice.

--- a/src/HaskellCI/Config/Grammar.hs
+++ b/src/HaskellCI/Config/Grammar.hs
@@ -79,7 +79,7 @@ configGrammar = Config
     <*> optionalFieldDef    "jobs-selection"                                                (field @"cfgTestedWith") defaultConfig
         ^^^ metahelp "uniform|any" "Jobs selection across packages"
     <*> rangeField            "enabled"                                                     (field @"cfgEnabledJobs") defaultConfig
-        ^^^ metahelp "RANGE" "Restrict jobs selection futher from per package tested-with"
+        ^^^ metahelp "RANGE" "Restrict jobs selection further from per package tested-with"
     <*> optionalFieldDef    "copy-fields"                                                   (field @"cfgCopyFields") defaultConfig
         ^^^ metahelp "none|some|all" "Copy ? fields from cabal.project fields"
     <*> monoidalFieldAla    "local-ghc-options"         (C.alaList' C.NoCommaFSep C.Token') (field @"cfgLocalGhcOptions")

--- a/src/HaskellCI/Sh.hs
+++ b/src/HaskellCI/Sh.hs
@@ -74,7 +74,7 @@ sh = sh'
     , 2046
     , 2210
 {-
-SC1102: Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors.
+SC1102: Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetic)), fix parsing errors.
 SC2046: Quote this to prevent word splitting.
 SC2210: This is a file redirection. Was it supposed to be a comparison or fd operation?
 -}


### PR DESCRIPTION
Found via `codespell -L appar,ede,shs,te,benchs`